### PR TITLE
Fix MCP orchestrator dependencies not bundled in packaged app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "lint": "eslint",
     "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
     "electron:start": "wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
-    "electron:build": "mv src/app/api src/app/_api_backup && mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null; ELECTRON_BUILD=1 next build; mv src/app/_api_backup src/app/api && mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null; tsc -p electron/tsconfig.json && electron-builder --mac",
-    "electron:pack": "tsc -p electron/tsconfig.json && electron-builder --dir --mac"
+    "electron:build": "mv src/app/api src/app/_api_backup && mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null; ELECTRON_BUILD=1 next build; mv src/app/_api_backup src/app/api && mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null; tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && electron-builder --mac",
+    "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && electron-builder --dir --mac"
   },
   "build": {
     "appId": "com.octav.claudemgr",


### PR DESCRIPTION
## Summary
- Fixed a packaging bug where the MCP orchestrator's `node_modules` were not being installed before bundling
- Added dependency installation and TypeScript compilation steps to `electron:build` and `electron:pack` scripts
- This ensures the packaged app includes all required dependencies for the MCP server to function

## Problem
When installing claude.mgr from the packaged DMG, the MCP tools (like `send_telegram`, `list_agents`, etc.) fail to work because the `mcp-orchestrator/node_modules` directory is empty. Users had to manually run `sudo npm install` inside the app bundle to fix it.

## Solution
Updated the build scripts to run `cd mcp-orchestrator && npm install && npm run build && cd ..` before `electron-builder` packages the app.

## Test plan
- [ ] Run `npm run electron:build` and verify the DMG is created
- [ ] Install the app and check that `mcp-orchestrator/node_modules` contains the dependencies
- [ ] Verify MCP tools work in Claude Code without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)