### PR TITLE
feat: refactor api-server into modular routes, fix skills marketplace…

### DIFF
--- a/__tests__/electron/services/api-routes/agent-routes.test.ts
+++ b/__tests__/electron/services/api-routes/agent-routes.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+const mockPtyProcess = {
+  onData: vi.fn(),
+  onExit: vi.fn(),
+  kill: vi.fn(),
+  write: vi.fn(),
+};
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(() => mockPtyProcess),
+}));
+
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => 'test-uuid'),
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/Users/test' },
+  BrowserWindow: vi.fn(),
+}));
+
+vi.mock('../../../../electron/core/agent-manager', () => ({
+  agents: new Map(),
+  saveAgents: vi.fn(),
+  initAgentPty: vi.fn(),
+}));
+
+vi.mock('../../../../electron/core/pty-manager', () => ({
+  ptyProcesses: new Map(),
+  writeProgrammaticInput: vi.fn(),
+}));
+
+vi.mock('../../../../electron/utils/path-builder', () => ({
+  buildFullPath: vi.fn(() => '/usr/bin'),
+}));
+
+import { registerAgentRoutes } from '../../../../electron/services/api-routes/agent-routes';
+import { agents, saveAgents } from '../../../../electron/core/agent-manager';
+import { ptyProcesses, writeProgrammaticInput } from '../../../../electron/core/pty-manager';
+import { RouteApp, RouteContext, RouteRequest, SendJson } from '../../../../electron/services/api-routes/types';
+import { AgentStatus, AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+function makeAgent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+  return {
+    id: 'agent-1',
+    status: 'idle',
+    projectPath: '/test/project',
+    skills: [],
+    output: [],
+    lastActivity: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    method: 'GET',
+    pathname: '',
+    url: new URL('http://localhost/'),
+    body: {},
+    raw: {} as any,
+    res: {} as any,
+    params: {},
+    ...overrides,
+  };
+}
+
+let ctx: RouteContext;
+
+beforeEach(() => {
+  agents.clear();
+  ptyProcesses.clear();
+  vi.mocked(saveAgents).mockClear();
+  mockPtyProcess.onData.mockClear();
+  mockPtyProcess.onExit.mockClear();
+  mockPtyProcess.kill.mockClear();
+
+  ctx = {
+    mainWindow: { isDestroyed: () => false, webContents: { send: vi.fn() } } as any,
+    appSettings: {} as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(async () => 'new-pty-id'),
+    agentStatusEmitter: new EventEmitter(),
+  };
+});
+
+describe('agent-routes', () => {
+  function findHandler(app: RouteApp, method: string, patternStr: string) {
+    return app.routes.find(r => r.method === method && String(r.pattern).includes(patternStr))!.handler;
+  }
+
+  describe('GET /api/agents', () => {
+    it('returns list of agents', async () => {
+      agents.set('a1', makeAgent({ id: 'a1', name: 'Agent A' }));
+      agents.set('a2', makeAgent({ id: 'a2', name: 'Agent B' }));
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/agents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq(), sendJson, ctx);
+
+      expect(sendJson).toHaveBeenCalledTimes(1);
+      const result = sendJson.mock.calls[0][0];
+      expect(result.agents).toHaveLength(2);
+    });
+  });
+
+  describe('GET /api/agents/:id', () => {
+    it('returns single agent', async () => {
+      const agent = makeAgent({ id: 'a1' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'agents\\/([^/]+)$');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'a1' } }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ agent });
+    });
+
+    it('returns 404 for missing agent', async () => {
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'agents\\/([^/]+)$');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'nope' } }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'Agent not found' }, 404);
+    });
+  });
+
+  describe('GET /api/agents/:id/output', () => {
+    it('returns agent output', async () => {
+      const agent = makeAgent({ id: 'a1', output: ['line1', 'line2', 'line3'], status: 'running' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'output');
+
+      const sendJson = vi.fn();
+      const url = new URL('http://localhost/api/agents/a1/output?lines=2');
+      await handler(makeReq({ params: { id: 'a1' }, url }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ output: 'line2line3', status: 'running' });
+    });
+  });
+
+  describe('POST /api/agents', () => {
+    it('creates a new agent', async () => {
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/agents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: { projectPath: '/my/project', name: 'Test Agent' } }), sendJson, ctx);
+
+      expect(sendJson).toHaveBeenCalledTimes(1);
+      const result = sendJson.mock.calls[0][0];
+      expect(result.agent.name).toBe('Test Agent');
+      expect(result.agent.status).toBe('idle');
+      expect(agents.size).toBe(1);
+      expect(saveAgents).toHaveBeenCalled();
+    });
+
+    it('returns 400 without projectPath', async () => {
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/agents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: {} }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'projectPath is required' }, 400);
+    });
+  });
+
+  describe('POST /api/agents/:id/stop', () => {
+    it('stops a running agent', async () => {
+      const mockPty = { kill: vi.fn() };
+      ptyProcesses.set('pty-1', mockPty as any);
+      const agent = makeAgent({ id: 'a1', status: 'running', ptyId: 'pty-1' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'POST', 'stop');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'a1' } }), sendJson, ctx);
+
+      expect(mockPty.kill).toHaveBeenCalled();
+      expect(agent.status).toBe('idle');
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+  });
+
+  describe('POST /api/agents/:id/message', () => {
+    it('sends message to agent PTY', async () => {
+      const mockPty = { write: vi.fn() };
+      ptyProcesses.set('pty-1', mockPty as any);
+      const agent = makeAgent({ id: 'a1', status: 'running', ptyId: 'pty-1' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'POST', 'message');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'a1' }, body: { message: 'hello' } }), sendJson, ctx);
+
+      expect(writeProgrammaticInput).toHaveBeenCalledWith(mockPty, 'hello');
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('initializes PTY if not present', async () => {
+      const mockPty = { write: vi.fn() };
+      const agent = makeAgent({ id: 'a1', status: 'waiting' });
+      agents.set('a1', agent);
+
+      // initAgentPtyCallback returns 'new-pty-id', so set up that PTY
+      ptyProcesses.set('new-pty-id', mockPty as any);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'POST', 'message');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'a1' }, body: { message: 'hello' } }), sendJson, ctx);
+
+      expect(ctx.initAgentPtyCallback).toHaveBeenCalledWith(agent);
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+  });
+
+  describe('DELETE /api/agents/:id', () => {
+    it('deletes agent and kills PTY', async () => {
+      const mockPty = { kill: vi.fn() };
+      ptyProcesses.set('pty-1', mockPty as any);
+      const agent = makeAgent({ id: 'a1', ptyId: 'pty-1' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'DELETE', 'agents');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'a1' } }), sendJson, ctx);
+
+      expect(mockPty.kill).toHaveBeenCalled();
+      expect(agents.has('a1')).toBe(false);
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+  });
+
+  describe('GET /api/agents/:id/wait', () => {
+    it('returns immediately for terminal state', async () => {
+      const agent = makeAgent({ id: 'a1', status: 'completed', lastCleanOutput: 'done' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerAgentRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'wait');
+
+      const sendJson = vi.fn();
+      const url = new URL('http://localhost/api/agents/a1/wait');
+      await handler(makeReq({ params: { id: 'a1' }, url }), sendJson, ctx);
+
+      expect(sendJson).toHaveBeenCalledWith({
+        status: 'completed',
+        lastCleanOutput: 'done',
+        error: undefined,
+      });
+    });
+  });
+});

--- a/__tests__/electron/services/api-routes/health-routes.test.ts
+++ b/__tests__/electron/services/api-routes/health-routes.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { registerHealthRoutes } from '../../../../electron/services/api-routes/health-routes';
+import { RouteApp, RouteContext, RouteRequest, SendJson } from '../../../../electron/services/api-routes/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+const mockCtx = {} as RouteContext;
+
+describe('health-routes', () => {
+  it('registers GET /api/health', () => {
+    const app = makeRouteApp();
+    registerHealthRoutes(app, mockCtx);
+    expect(app.routes).toHaveLength(1);
+    expect(app.routes[0].method).toBe('GET');
+    expect(app.routes[0].pattern).toBe('/api/health');
+  });
+
+  it('returns { ok: true }', async () => {
+    const app = makeRouteApp();
+    registerHealthRoutes(app, mockCtx);
+
+    const sendJson = vi.fn() as unknown as SendJson;
+    const req = { params: {} } as RouteRequest;
+    await app.routes[0].handler(req, sendJson, mockCtx);
+    expect(sendJson).toHaveBeenCalledWith({ ok: true });
+  });
+});

--- a/__tests__/electron/services/api-routes/hooks-routes.test.ts
+++ b/__tests__/electron/services/api-routes/hooks-routes.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('../../../../electron/core/agent-manager', () => ({
+  agents: new Map(),
+  saveAgents: vi.fn(),
+}));
+
+import { registerHooksRoutes } from '../../../../electron/services/api-routes/hooks-routes';
+import { agents, saveAgents } from '../../../../electron/core/agent-manager';
+import { RouteApp, RouteContext, RouteRequest, SendJson } from '../../../../electron/services/api-routes/types';
+import { AgentStatus, AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+function makeAgent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+  return {
+    id: 'agent-1',
+    status: 'idle',
+    projectPath: '/test',
+    skills: [],
+    output: [],
+    lastActivity: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeReq(body: Record<string, unknown>): RouteRequest {
+  return { body, params: {} } as RouteRequest;
+}
+
+let ctx: RouteContext;
+
+beforeEach(() => {
+  agents.clear();
+  vi.mocked(saveAgents).mockClear();
+  ctx = {
+    mainWindow: { isDestroyed: () => false, webContents: { send: vi.fn() } } as any,
+    appSettings: { notifyOnWaiting: true } as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: new EventEmitter(),
+  };
+});
+
+describe('hooks-routes', () => {
+  function getHandler(app: RouteApp, pattern: string) {
+    return app.routes.find(r => r.pattern === pattern)!.handler;
+  }
+
+  describe('POST /api/hooks/output', () => {
+    it('captures output on agent', async () => {
+      const agent = makeAgent();
+      agents.set('agent-1', agent);
+
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/output');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'agent-1', output: 'hello world' }), sendJson, ctx);
+
+      expect(agent.lastCleanOutput).toBe('hello world');
+      expect(saveAgents).toHaveBeenCalled();
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 when agent_id or output missing', async () => {
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/output');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'agent-1' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'agent_id and output are required' }, 400);
+    });
+
+    it('finds agent by session_id fallback', async () => {
+      const agent = makeAgent({ id: 'a2', currentSessionId: 'sess-1' });
+      agents.set('a2', agent);
+
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/output');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'unknown', session_id: 'sess-1', output: 'hi' }), sendJson, ctx);
+      expect(agent.lastCleanOutput).toBe('hi');
+    });
+  });
+
+  describe('POST /api/hooks/status', () => {
+    it('transitions agent status and emits events', async () => {
+      const agent = makeAgent({ id: 'a1', status: 'idle' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/status');
+
+      const sendJson = vi.fn();
+      const emitSpy = vi.spyOn(ctx.agentStatusEmitter, 'emit');
+      await handler(makeReq({ agent_id: 'a1', session_id: 'sess', status: 'running' }), sendJson, ctx);
+
+      expect(agent.status).toBe('running');
+      expect(agent.currentSessionId).toBe('sess');
+      expect(ctx.handleStatusChangeNotificationCallback).toHaveBeenCalledWith(agent, 'running');
+      expect(emitSpy).toHaveBeenCalledWith('status:a1');
+      expect(sendJson).toHaveBeenCalledWith({ success: true, agent: { id: 'a1', status: 'running' } });
+    });
+
+    it('returns 400 when agent_id or status missing', async () => {
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/status');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'a1' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'agent_id and status are required' }, 400);
+    });
+
+    it('returns not found for unknown agent', async () => {
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/status');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'nope', status: 'running' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ success: false, message: 'Agent not found' });
+    });
+  });
+
+  describe('POST /api/hooks/notification', () => {
+    it('sends permission_prompt notification', async () => {
+      const agent = makeAgent({ id: 'a1', name: 'MyAgent' });
+      agents.set('a1', agent);
+
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/notification');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'a1', session_id: 'sess', type: 'permission_prompt', title: 'Test', message: 'help' }), sendJson, ctx);
+
+      expect(ctx.sendNotificationCallback).toHaveBeenCalledWith('MyAgent needs permission', 'help', 'a1');
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 when agent_id or type missing', async () => {
+      const app = makeRouteApp();
+      registerHooksRoutes(app, ctx);
+      const handler = getHandler(app, '/api/hooks/notification');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ agent_id: 'a1' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'agent_id and type are required' }, 400);
+    });
+  });
+});

--- a/__tests__/electron/services/api-routes/kanban-routes.test.ts
+++ b/__tests__/electron/services/api-routes/kanban-routes.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../electron/core/agent-manager', () => ({
+  agents: new Map(),
+  saveAgents: vi.fn(),
+}));
+
+vi.mock('../../../../electron/utils/kanban-generate', () => ({
+  generateTaskFromPrompt: vi.fn(async (prompt: string) => ({
+    title: `Generated: ${prompt}`,
+    description: 'Auto-generated',
+  })),
+}));
+
+const mockLoadTasks = vi.fn(() => []);
+const mockSaveTasks = vi.fn();
+
+vi.mock('../../../../electron/handlers/kanban-handlers', () => ({
+  loadTasks: (...args: unknown[]) => mockLoadTasks(...args),
+  saveTasks: (...args: unknown[]) => mockSaveTasks(...args),
+}));
+
+import { registerKanbanRoutes } from '../../../../electron/services/api-routes/kanban-routes';
+import { agents } from '../../../../electron/core/agent-manager';
+import { RouteApp, RouteContext, RouteRequest } from '../../../../electron/services/api-routes/types';
+import { AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+let ctx: RouteContext;
+
+beforeEach(() => {
+  agents.clear();
+  mockLoadTasks.mockClear();
+  mockSaveTasks.mockClear();
+
+  ctx = {
+    mainWindow: { isDestroyed: () => false, webContents: { send: vi.fn() } } as any,
+    appSettings: {} as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: {} as any,
+  };
+});
+
+describe('kanban-routes', () => {
+  function getHandler(app: RouteApp, pattern: string) {
+    return app.routes.find(r => r.pattern === pattern)!.handler;
+  }
+
+  describe('POST /api/kanban/generate', () => {
+    it('generates task from prompt', async () => {
+      const app = makeRouteApp();
+      registerKanbanRoutes(app, ctx);
+      const handler = getHandler(app, '/api/kanban/generate');
+
+      const sendJson = vi.fn();
+      await handler({ body: { prompt: 'Fix bug', availableProjects: [] }, params: {} } as RouteRequest, sendJson, ctx);
+
+      expect(sendJson).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        task: expect.objectContaining({ title: 'Generated: Fix bug' }),
+      }));
+    });
+
+    it('returns 400 when prompt missing', async () => {
+      const app = makeRouteApp();
+      registerKanbanRoutes(app, ctx);
+      const handler = getHandler(app, '/api/kanban/generate');
+
+      const sendJson = vi.fn();
+      await handler({ body: {}, params: {} } as RouteRequest, sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'prompt is required' }, 400);
+    });
+  });
+
+  describe('POST /api/kanban/complete', () => {
+    it('completes task by task_id', async () => {
+      mockLoadTasks.mockReturnValue([
+        { id: 'task-1', title: 'Test', column: 'ongoing', assignedAgentId: 'a1' },
+      ]);
+
+      const app = makeRouteApp();
+      registerKanbanRoutes(app, ctx);
+      const handler = getHandler(app, '/api/kanban/complete');
+
+      const sendJson = vi.fn();
+      await handler({ body: { task_id: 'task-1', summary: 'done' }, params: {} } as RouteRequest, sendJson, ctx);
+
+      expect(mockSaveTasks).toHaveBeenCalled();
+      const result = sendJson.mock.calls[0][0];
+      expect(result.success).toBe(true);
+      expect(result.task.column).toBe('done');
+      expect(result.task.progress).toBe(100);
+    });
+
+    it('returns success when no task found', async () => {
+      mockLoadTasks.mockReturnValue([]);
+      const app = makeRouteApp();
+      registerKanbanRoutes(app, ctx);
+      const handler = getHandler(app, '/api/kanban/complete');
+
+      const sendJson = vi.fn();
+      await handler({ body: { agent_id: 'nope' }, params: {} } as RouteRequest, sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith(expect.objectContaining({
+        success: true,
+        message: 'No kanban task found for this agent',
+      }));
+    });
+
+    it('finds task by agent session_id', async () => {
+      agents.set('a1', { id: 'a1', currentSessionId: 'sess-1' } as any);
+      mockLoadTasks.mockReturnValue([
+        { id: 'task-1', title: 'Test', column: 'ongoing', assignedAgentId: 'a1' },
+      ]);
+
+      const app = makeRouteApp();
+      registerKanbanRoutes(app, ctx);
+      const handler = getHandler(app, '/api/kanban/complete');
+
+      const sendJson = vi.fn();
+      await handler({ body: { session_id: 'sess-1' }, params: {} } as RouteRequest, sendJson, ctx);
+
+      const result = sendJson.mock.calls[0][0];
+      expect(result.success).toBe(true);
+      expect(result.task.column).toBe('done');
+    });
+  });
+});

--- a/__tests__/electron/services/api-routes/scheduler-routes.test.ts
+++ b/__tests__/electron/services/api-routes/scheduler-routes.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { registerSchedulerRoutes } from '../../../../electron/services/api-routes/scheduler-routes';
+import { RouteApp, RouteContext, RouteRequest } from '../../../../electron/services/api-routes/types';
+import { AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+let ctx: RouteContext;
+let tmpDir: string;
+
+vi.mock('os', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('os')>();
+  return { ...mod, homedir: () => tmpDir };
+});
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sched-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.dorothy'), { recursive: true });
+
+  ctx = {
+    mainWindow: { isDestroyed: () => false, webContents: { send: vi.fn() } } as any,
+    appSettings: {} as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: {} as any,
+  };
+});
+
+afterEach(() => {
+  if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('scheduler-routes', () => {
+  it('writes scheduler metadata', async () => {
+    const app = makeRouteApp();
+    registerSchedulerRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler(
+      { body: { task_id: 'task-1', status: 'success', summary: 'all good' }, params: {} } as RouteRequest,
+      sendJson,
+      ctx
+    );
+
+    expect(sendJson).toHaveBeenCalledWith({ success: true });
+
+    const metadataPath = path.join(tmpDir, '.dorothy', 'scheduler-metadata.json');
+    expect(fs.existsSync(metadataPath)).toBe(true);
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+    expect(metadata['task-1'].lastRunStatus).toBe('success');
+    expect(metadata['task-1'].lastRunSummary).toBe('all good');
+  });
+
+  it('returns 400 when task_id or status missing', async () => {
+    const app = makeRouteApp();
+    registerSchedulerRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler(
+      { body: { task_id: 'task-1' }, params: {} } as RouteRequest,
+      sendJson,
+      ctx
+    );
+    expect(sendJson).toHaveBeenCalledWith({ error: 'task_id and status are required' }, 400);
+  });
+
+  it('returns 400 for invalid status', async () => {
+    const app = makeRouteApp();
+    registerSchedulerRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler(
+      { body: { task_id: 'task-1', status: 'invalid' }, params: {} } as RouteRequest,
+      sendJson,
+      ctx
+    );
+    expect(sendJson).toHaveBeenCalledWith(expect.objectContaining({ error: expect.stringContaining('Invalid status') }), 400);
+  });
+
+  it('emits event to frontend', async () => {
+    const app = makeRouteApp();
+    registerSchedulerRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler(
+      { body: { task_id: 'task-2', status: 'running' }, params: {} } as RouteRequest,
+      sendJson,
+      ctx
+    );
+
+    expect(ctx.mainWindow!.webContents.send).toHaveBeenCalledWith('scheduler:task-status', {
+      taskId: 'task-2',
+      status: 'running',
+      summary: undefined,
+    });
+  });
+});

--- a/__tests__/electron/services/api-routes/slack-routes.test.ts
+++ b/__tests__/electron/services/api-routes/slack-routes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { registerSlackRoutes } from '../../../../electron/services/api-routes/slack-routes';
+import { RouteApp, RouteContext, RouteRequest } from '../../../../electron/services/api-routes/types';
+import { AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+const mockPostMessage = vi.fn();
+let ctx: RouteContext;
+
+beforeEach(() => {
+  mockPostMessage.mockReset();
+  ctx = {
+    mainWindow: null,
+    appSettings: { slackChannelId: 'C123' } as unknown as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => ({
+      client: { chat: { postMessage: mockPostMessage } },
+    }) as any,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: {} as any,
+  };
+});
+
+describe('slack-routes', () => {
+  it('sends message to Slack', async () => {
+    mockPostMessage.mockResolvedValue(undefined);
+    const app = makeRouteApp();
+    registerSlackRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler({ body: { message: 'Hello' }, params: {} } as RouteRequest, sendJson, ctx);
+
+    expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({
+      channel: 'C123',
+      text: ':crown: Hello',
+    }));
+    expect(sendJson).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('uses thread_ts when available', async () => {
+    ctx.slackResponseThreadTs = 'ts-123';
+    mockPostMessage.mockResolvedValue(undefined);
+    const app = makeRouteApp();
+    registerSlackRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler({ body: { message: 'Reply' }, params: {} } as RouteRequest, sendJson, ctx);
+
+    expect(mockPostMessage).toHaveBeenCalledWith(expect.objectContaining({
+      thread_ts: 'ts-123',
+    }));
+  });
+
+  it('returns 400 when message missing', async () => {
+    const app = makeRouteApp();
+    registerSlackRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler({ body: {}, params: {} } as RouteRequest, sendJson, ctx);
+    expect(sendJson).toHaveBeenCalledWith({ error: 'message is required' }, 400);
+  });
+
+  it('returns 400 when slack not configured', async () => {
+    ctx.getSlackApp = () => null;
+    const app = makeRouteApp();
+    registerSlackRoutes(app, ctx);
+
+    const sendJson = vi.fn();
+    await app.routes[0].handler({ body: { message: 'hi' }, params: {} } as RouteRequest, sendJson, ctx);
+    expect(sendJson).toHaveBeenCalledWith({ error: 'Slack not configured or no channel ID' }, 400);
+  });
+});

--- a/__tests__/electron/services/api-routes/telegram-routes.test.ts
+++ b/__tests__/electron/services/api-routes/telegram-routes.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+import { registerTelegramRoutes } from '../../../../electron/services/api-routes/telegram-routes';
+import { RouteApp, RouteContext, RouteRequest, SendJson } from '../../../../electron/services/api-routes/types';
+import { AppSettings } from '../../../../electron/types';
+
+vi.mock('../../../../electron/core/agent-manager', () => ({
+  agents: new Map(),
+  saveAgents: vi.fn(),
+}));
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+function makeReq(body: Record<string, unknown>): RouteRequest {
+  return { body, params: {} } as RouteRequest;
+}
+
+let ctx: RouteContext;
+const mockSendMessage = vi.fn();
+const mockSendPhoto = vi.fn();
+const mockSendVideo = vi.fn();
+const mockSendDocument = vi.fn();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockSendMessage.mockReset();
+  mockSendPhoto.mockReset();
+  mockSendVideo.mockReset();
+  mockSendDocument.mockReset();
+
+  ctx = {
+    mainWindow: null,
+    appSettings: {
+      telegramChatId: '12345',
+      telegramAuthorizedChatIds: ['12345'],
+    } as unknown as AppSettings,
+    getTelegramBot: () => ({
+      sendMessage: mockSendMessage,
+      sendPhoto: mockSendPhoto,
+      sendVideo: mockSendVideo,
+      sendDocument: mockSendDocument,
+    }) as any,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: {} as any,
+  };
+});
+
+describe('telegram-routes', () => {
+  function getHandler(app: RouteApp, pattern: string) {
+    return app.routes.find(r => r.pattern === pattern)!.handler;
+  }
+
+  describe('POST /api/telegram/send', () => {
+    it('sends message via telegram', async () => {
+      mockSendMessage.mockResolvedValue(undefined);
+      const app = makeRouteApp();
+      registerTelegramRoutes(app, ctx);
+      const handler = getHandler(app, '/api/telegram/send');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ message: 'Hello' }), sendJson, ctx);
+      expect(mockSendMessage).toHaveBeenCalled();
+      expect(sendJson).toHaveBeenCalledWith({ success: true });
+    });
+
+    it('returns 400 when message missing', async () => {
+      const app = makeRouteApp();
+      registerTelegramRoutes(app, ctx);
+      const handler = getHandler(app, '/api/telegram/send');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({}), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'message is required' }, 400);
+    });
+
+    it('returns 400 when bot not configured', async () => {
+      ctx.getTelegramBot = () => null;
+      const app = makeRouteApp();
+      registerTelegramRoutes(app, ctx);
+      const handler = getHandler(app, '/api/telegram/send');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ message: 'hello' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.stringContaining('Telegram not configured') }),
+        400
+      );
+    });
+  });
+
+  describe('POST /api/telegram/send-photo', () => {
+    it('returns 400 when photo_path missing', async () => {
+      const app = makeRouteApp();
+      registerTelegramRoutes(app, ctx);
+      const handler = getHandler(app, '/api/telegram/send-photo');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({}), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'photo_path is required' }, 400);
+    });
+
+    it('returns 403 for unsafe path', async () => {
+      const app = makeRouteApp();
+      registerTelegramRoutes(app, ctx);
+      const handler = getHandler(app, '/api/telegram/send-photo');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ photo_path: '/etc/passwd' }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'Access denied: path not allowed' }, 403);
+    });
+  });
+});

--- a/__tests__/electron/services/api-routes/utils.test.ts
+++ b/__tests__/electron/services/api-routes/utils.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as os from 'os';
+import * as path from 'path';
+
+vi.mock('../../../../electron/core/agent-manager', () => ({
+  agents: new Map(),
+  saveAgents: vi.fn(),
+}));
+
+import { isSafeTelegramPath, findAgentByIdOrSession } from '../../../../electron/services/api-routes/utils';
+import { agents } from '../../../../electron/core/agent-manager';
+import { AgentStatus } from '../../../../electron/types';
+
+function makeAgent(overrides: Partial<AgentStatus> = {}): AgentStatus {
+  return {
+    id: 'agent-1',
+    status: 'idle',
+    projectPath: '/test',
+    skills: [],
+    output: [],
+    lastActivity: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('isSafeTelegramPath', () => {
+  const home = os.homedir();
+
+  it('allows paths within home directory', () => {
+    expect(isSafeTelegramPath(path.join(home, 'Documents', 'file.txt'))).toBe(true);
+  });
+
+  it('blocks paths outside home directory', () => {
+    expect(isSafeTelegramPath('/etc/passwd')).toBe(false);
+  });
+
+  it('blocks .ssh directory', () => {
+    expect(isSafeTelegramPath(path.join(home, '.ssh', 'id_rsa'))).toBe(false);
+  });
+
+  it('blocks .aws directory', () => {
+    expect(isSafeTelegramPath(path.join(home, '.aws', 'credentials'))).toBe(false);
+  });
+
+  it('blocks .claude directory', () => {
+    expect(isSafeTelegramPath(path.join(home, '.claude', 'config'))).toBe(false);
+  });
+
+  it('blocks .gnupg directory', () => {
+    expect(isSafeTelegramPath(path.join(home, '.gnupg', 'secret'))).toBe(false);
+  });
+
+  it('blocks .env directory', () => {
+    expect(isSafeTelegramPath(path.join(home, '.env', 'secrets'))).toBe(false);
+  });
+});
+
+describe('findAgentByIdOrSession', () => {
+  beforeEach(() => {
+    agents.clear();
+  });
+
+  it('finds agent by id', () => {
+    const agent = makeAgent({ id: 'a1' });
+    agents.set('a1', agent);
+    expect(findAgentByIdOrSession('a1')).toBe(agent);
+  });
+
+  it('finds agent by session id when id lookup fails', () => {
+    const agent = makeAgent({ id: 'a2', currentSessionId: 'sess-1' });
+    agents.set('a2', agent);
+    expect(findAgentByIdOrSession('unknown', 'sess-1')).toBe(agent);
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findAgentByIdOrSession('nope', 'nope')).toBeUndefined();
+  });
+
+  it('returns undefined when no args provided', () => {
+    expect(findAgentByIdOrSession()).toBeUndefined();
+  });
+});

--- a/__tests__/electron/services/api-routes/vault-routes.test.ts
+++ b/__tests__/electron/services/api-routes/vault-routes.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => 'vault-uuid'),
+}));
+
+vi.mock('../../../../electron/constants', () => ({
+  VAULT_DIR: '/tmp/vault-test',
+  MIME_TYPES: { '.png': 'image/png', '.jpg': 'image/jpeg' },
+}));
+
+const mockPrepare = vi.fn();
+const mockDb = {
+  prepare: mockPrepare,
+};
+
+vi.mock('../../../../electron/services/vault-db', () => ({
+  getVaultDb: () => mockDb,
+}));
+
+import { registerVaultRoutes } from '../../../../electron/services/api-routes/vault-routes';
+import { RouteApp, RouteContext, RouteRequest } from '../../../../electron/services/api-routes/types';
+import { AppSettings } from '../../../../electron/types';
+
+function makeRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+function makeReq(overrides: Partial<RouteRequest> = {}): RouteRequest {
+  return {
+    method: 'GET',
+    pathname: '',
+    url: new URL('http://localhost/'),
+    body: {},
+    raw: {} as any,
+    res: {} as any,
+    params: {},
+    ...overrides,
+  };
+}
+
+let ctx: RouteContext;
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  mockPrepare.mockReset();
+
+  ctx = {
+    mainWindow: { isDestroyed: () => false, webContents: { send: vi.fn() } } as any,
+    appSettings: {} as AppSettings,
+    getTelegramBot: () => null,
+    getSlackApp: () => null,
+    slackResponseChannel: null,
+    slackResponseThreadTs: null,
+    handleStatusChangeNotificationCallback: vi.fn(),
+    sendNotificationCallback: vi.fn(),
+    initAgentPtyCallback: vi.fn(),
+    agentStatusEmitter: {} as any,
+  };
+});
+
+describe('vault-routes', () => {
+  function findHandler(app: RouteApp, method: string, patternStr: string) {
+    return app.routes.find(r => r.method === method && String(r.pattern).includes(patternStr))!.handler;
+  }
+
+  describe('GET /api/vault/documents', () => {
+    it('returns documents', async () => {
+      const docs = [{ id: 'd1', title: 'Doc 1' }];
+      mockPrepare.mockReturnValue({ all: vi.fn(() => docs) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/vault/documents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ url: new URL('http://localhost/api/vault/documents') }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ documents: docs });
+    });
+
+    it('filters by folder_id', async () => {
+      const allMock = vi.fn(() => []);
+      mockPrepare.mockReturnValue({ all: allMock });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/vault/documents')!.handler;
+
+      const sendJson = vi.fn();
+      const url = new URL('http://localhost/api/vault/documents?folder_id=f1');
+      await handler(makeReq({ url }), sendJson, ctx);
+
+      // Verify the query was called with the folder filter
+      expect(mockPrepare).toHaveBeenCalled();
+      expect(sendJson).toHaveBeenCalledWith({ documents: [] });
+    });
+  });
+
+  describe('POST /api/vault/documents', () => {
+    it('creates a document', async () => {
+      const newDoc = { id: 'vault-uuid', title: 'New Doc' };
+      mockPrepare
+        .mockReturnValueOnce({ run: vi.fn() })
+        .mockReturnValueOnce({ get: vi.fn(() => newDoc) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/vault/documents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: { title: 'New Doc', content: 'Content' } }), sendJson, ctx);
+
+      expect(sendJson).toHaveBeenCalledWith({ success: true, document: newDoc });
+      expect(ctx.mainWindow!.webContents.send).toHaveBeenCalledWith('vault:document-created', newDoc);
+    });
+
+    it('returns 400 when title missing', async () => {
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/vault/documents')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: {} }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'title is required' }, 400);
+    });
+  });
+
+  describe('GET /api/vault/documents/:id', () => {
+    it('returns document with attachments', async () => {
+      const doc = { id: 'd1', title: 'Doc' };
+      const attachments = [{ id: 'a1' }];
+      mockPrepare
+        .mockReturnValueOnce({ get: vi.fn(() => doc) })
+        .mockReturnValueOnce({ all: vi.fn(() => attachments) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'documents\\/([^/]+)$');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'd1' } }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ document: doc, attachments });
+    });
+
+    it('returns 404 when not found', async () => {
+      mockPrepare.mockReturnValue({ get: vi.fn(() => undefined) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = findHandler(app, 'GET', 'documents\\/([^/]+)$');
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ params: { id: 'nope' } }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'Document not found' }, 404);
+    });
+  });
+
+  describe('GET /api/vault/search', () => {
+    it('returns search results', async () => {
+      const results = [{ id: 'd1', snippet: 'test' }];
+      mockPrepare.mockReturnValue({ all: vi.fn(() => results) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/vault/search')!.handler;
+
+      const sendJson = vi.fn();
+      const url = new URL('http://localhost/api/vault/search?q=test');
+      await handler(makeReq({ url }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ results });
+    });
+
+    it('returns 400 without query', async () => {
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/vault/search')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ url: new URL('http://localhost/api/vault/search') }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'q parameter is required' }, 400);
+    });
+  });
+
+  describe('GET /api/vault/folders', () => {
+    it('returns folders', async () => {
+      const folders = [{ id: 'f1', name: 'Folder' }];
+      mockPrepare.mockReturnValue({ all: vi.fn(() => folders) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/vault/folders')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq(), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ folders });
+    });
+  });
+
+  describe('POST /api/vault/folders', () => {
+    it('creates a folder', async () => {
+      const folder = { id: 'vault-uuid', name: 'New' };
+      mockPrepare
+        .mockReturnValueOnce({ run: vi.fn() })
+        .mockReturnValueOnce({ get: vi.fn(() => folder) });
+
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/vault/folders')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: { name: 'New' } }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ success: true, folder });
+    });
+
+    it('returns 400 when name missing', async () => {
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'POST' && r.pattern === '/api/vault/folders')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ body: {} }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'name is required' }, 400);
+    });
+  });
+
+  describe('GET /api/local-file', () => {
+    it('returns 404 without path param', async () => {
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/local-file')!.handler;
+
+      const sendJson = vi.fn();
+      await handler(makeReq({ url: new URL('http://localhost/api/local-file') }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'File not found' }, 404);
+    });
+
+    it('returns 403 for path outside vault', async () => {
+      const app = makeRouteApp();
+      registerVaultRoutes(app, ctx);
+      const handler = app.routes.find(r => r.method === 'GET' && r.pattern === '/api/local-file')!.handler;
+
+      const sendJson = vi.fn();
+      const url = new URL('http://localhost/api/local-file?path=/etc/passwd');
+      await handler(makeReq({ url }), sendJson, ctx);
+      expect(sendJson).toHaveBeenCalledWith({ error: 'Access denied: path outside allowed directory' }, 403);
+    });
+  });
+});

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -852,6 +852,37 @@ function registerSkillHandlers(deps: IpcHandlerDependencies): void {
     return { success: false, error: 'PTY not found' };
   });
 
+  // Fetch skills marketplace from skills.sh (server-side to avoid CORS)
+  ipcMain.handle('skill:fetch-marketplace', async () => {
+    try {
+      const res = await fetch('https://skills.sh/', {
+        headers: { 'User-Agent': 'Dorothy/1.0' },
+      });
+      if (!res.ok) return { skills: null };
+
+      const html = await res.text();
+      const match = html.match(/initialSkills.*?(\[\{.*?\}\])/);
+      if (!match) return { skills: null };
+
+      const raw = match[1].replace(/\\"/g, '"');
+      const allSkills: { source: string; name: string; installs: number }[] = JSON.parse(raw);
+
+      const skills = allSkills.slice(0, 300).map((s, i) => ({
+        rank: i + 1,
+        name: s.name,
+        repo: s.source,
+        installs: s.installs >= 1000
+          ? `${(s.installs / 1000).toFixed(1).replace(/\.0$/, '')}K`
+          : String(s.installs),
+        installsNum: s.installs,
+      }));
+
+      return { skills };
+    } catch {
+      return { skills: null };
+    }
+  });
+
   // Legacy install (kept for backwards compatibility)
   ipcMain.handle('skill:install', async (_event, repo: string) => {
     // Just start the installation and return immediately

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -125,6 +125,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('skill:list-installed-all'),
     linkToProvider: (params: { skillName: string; providerId: string }) =>
       ipcRenderer.invoke('skill:link-to-provider', params),
+    fetchMarketplace: () =>
+      ipcRenderer.invoke('skill:fetch-marketplace') as Promise<{ skills: Array<{ rank: number; name: string; repo: string; installs: string; installsNum: number }> | null }>,
     onPtyData: (callback: (event: { id: string; data: string }) => void) => {
       const listener = (_: unknown, event: { id: string; data: string }) => callback(event);
       ipcRenderer.on('skill:pty-data', listener);

--- a/electron/resources/super-agent-instructions.md
+++ b/electron/resources/super-agent-instructions.md
@@ -4,15 +4,21 @@ You are the **Super Agent** - an orchestrator that manages other Claude agents u
 
 ## Available MCP Tools (from "claude-mgr-orchestrator")
 
+### Primary
+- `delegate_task`: **Start agent + wait + get result** in one call. This is your main tool for delegation.
 - `list_agents`: List all agents with status, project, ID
 - `get_agent`: Get detailed info about a specific agent
-- `get_agent_output`: Read agent's terminal output (use to see responses!)
+- `get_agent_output`: Read agent's clean text output (no terminal formatting)
+
+### Agent Control
 - `start_agent`: Start agent with a prompt (auto-sends to running agents too)
 - `send_message`: Send message to agent (auto-starts idle agents)
 - `stop_agent`: Stop a running agent
+- `wait_for_agent`: Wait for agent to complete (long-poll, returns immediately on status change)
 - `create_agent`: Create a new agent
 - `remove_agent`: Delete an agent
-- `wait_for_agent`: Wait for agent to complete
+
+### Communication
 - `send_telegram`: Send response back to Telegram
 - `send_slack`: Send response back to Slack
 
@@ -20,18 +26,29 @@ You are the **Super Agent** - an orchestrator that manages other Claude agents u
 
 1. You are an **agent manager only** - delegate actual coding tasks to other agents
 2. Use `list_agents` first to see available agents
-3. Use `start_agent` or `send_message` to give tasks to agents
-4. Use `get_agent_output` to check on agent progress and read their responses
-5. Use `wait_for_agent` to wait for task completion before checking output
+3. Use `delegate_task` for simple delegation (start + wait + get result)
+4. **Never send messages to "running" agents** — it may interfere with their work. Wait until they finish or reach "waiting" status first
+5. When an agent is "waiting", it needs input — use `send_message` to respond
 
 ## Workflow for Managing Agents
 
-1. Check current agents with `list_agents`
-2. Find or create the right agent for the task
-3. Send the task using `start_agent` (for idle agents) or `send_message` (for running/waiting agents)
-4. Wait for completion with `wait_for_agent` if needed
-5. Read results with `get_agent_output`
-6. Report back to the user
+### Simple Task (one agent)
+1. `list_agents` — find the right agent
+2. `delegate_task` — send task and get result in one call
+3. Report back to user (or via `send_telegram`/`send_slack`)
+
+### Complex Task (multiple agents)
+1. `list_agents` — find available agents
+2. `start_agent` on each agent with their respective tasks
+3. `wait_for_agent` on each (they run in parallel)
+4. `get_agent_output` to read results
+5. Synthesize and report back
+
+### When Agent Needs Input
+1. `wait_for_agent` returns with "waiting" status
+2. `get_agent_output` to see what it's asking
+3. `send_message` with the answer
+4. `wait_for_agent` again to wait for completion
 
 ## Telegram/Slack Requests
 
@@ -39,6 +56,47 @@ When a request comes from Telegram or Slack:
 - The message will indicate the source (e.g., "[FROM TELEGRAM]")
 - You MUST use `send_telegram` or `send_slack` to respond back
 - The user cannot see your terminal output - only messages sent via these tools
+- **CRITICAL: The user sees NOTHING unless you explicitly send a message.** You must narrate your actions in real time.
+
+### Mandatory Progress Updates Rule
+
+**Before EVERY blocking tool call** (`delegate_task`, `wait_for_agent`, `start_agent`), you MUST first call `send_telegram`/`send_slack` to tell the user what you're about to do. The user is on their phone waiting — silence feels broken.
+
+Pattern: **always message → then act → then message with result**
+
+### Telegram/Slack Workflow (Simple Task)
+1. `send_telegram("Looking at available agents...")`
+2. `list_agents` — find the right agent
+3. `send_telegram("Found [agent name]. Asking them to [task description]... This may take a moment.")`
+4. `delegate_task` — send task and wait
+5. `send_telegram("Done! Here's what [agent name] found: [result summary]")`
+
+### Telegram/Slack Workflow (Complex Task)
+1. `send_telegram("Got it. I'll coordinate multiple agents for this.")`
+2. `list_agents`
+3. `send_telegram("Starting [agent A] on [subtask A] and [agent B] on [subtask B]...")`
+4. `start_agent` on each
+5. `send_telegram("[Agent A] is working... waiting for results.")`
+6. `wait_for_agent` on first
+7. `send_telegram("[Agent A] finished. Now waiting on [Agent B]...")`
+8. `wait_for_agent` on second
+9. `get_agent_output` on each
+10. `send_telegram("All done! Here's the summary: [results]")`
+
+### Telegram/Slack Workflow (Agent Needs Input)
+1. `wait_for_agent` returns "waiting"
+2. `get_agent_output` to see the question
+3. `send_telegram("[Agent name] is asking: [question]. I'll handle this.")`
+4. `send_message` with the answer
+5. `send_telegram("Answered [agent name]'s question. Waiting for them to continue...")`
+6. `wait_for_agent` again
+
+### Message Style for Telegram/Slack
+- Keep updates concise but informative (1-2 lines)
+- Use agent names so the user knows who's doing what
+- Include estimated wait context: "This might take a minute..." for big tasks
+- On errors, explain what failed and what you're doing about it
+- Final messages should have concrete results, not just "Done"
 
 ## Autonomous Mode
 

--- a/electron/resources/telegram-instructions.md
+++ b/electron/resources/telegram-instructions.md
@@ -2,40 +2,71 @@
 
 For any Telegram-initiated task, you MUST follow this workflow:
 
-## Required Steps (All 4 are mandatory)
+## Golden Rule: Narrate Everything
 
-### Step 1: Acknowledge Receipt
-- Immediately confirm you received the request
-- Use `send_telegram` to acknowledge: "Received your request. Working on it..."
+The user is on their phone. They see NOTHING unless you send a message via `send_telegram`. Silence = broken. **Before every blocking operation, tell the user what you're about to do.**
 
-### Step 2: Execute the Operation
-- Perform the requested task (delegate to agents, run commands, etc.)
-- If delegating to an agent, use `start_agent` or `send_message`
-- Use `wait_for_agent` to wait for completion if needed
+## Required Pattern
 
-### Step 3: Verify Completion
-- Use `get_agent_output` to read results from delegated agents
-- Confirm the operation completed successfully
-- Gather specific output/results to report
+Every blocking tool call (`delegate_task`, `wait_for_agent`, `start_agent`) MUST be preceded by a `send_telegram` telling the user what's happening:
 
-### Step 4: Send Confirmation (CRITICAL)
-- Use `send_telegram` to send a results summary back to the user
-- Include specific details about what was done
-- Include any relevant output, errors, or next steps
-- **NEVER consider a task complete without this step**
+```
+send_telegram → blocking_call → send_telegram with result
+```
 
-## Example Workflow
+Never call two blocking tools in a row without a `send_telegram` between them.
 
-User request: "Run the tests for the auth module"
+## Step-by-Step Workflow
 
-1. `send_telegram("Received. Running auth module tests...")`
-2. `start_agent(id="test-agent", prompt="Run tests for auth module")`
-3. `wait_for_agent(id="test-agent")` then `get_agent_output(id="test-agent")`
-4. `send_telegram("Tests completed. Results: 15 passed, 0 failed. All auth tests passing.")`
+### Step 1: Acknowledge Receipt (immediate)
+- `send_telegram("Got it! Looking into this...")`
+- Do this FIRST, before any other tool call
+
+### Step 2: Narrate Before Acting
+Before each blocking operation, send a short update:
+- Before `list_agents`: `send_telegram("Checking which agents are available...")`
+- Before `delegate_task`: `send_telegram("Asking [agent name] to handle this. I'll let you know when they're done...")`
+- Before `wait_for_agent`: `send_telegram("Waiting on [agent name] to finish...")`
+- Before `start_agent`: `send_telegram("Starting [agent name] on [task]...")`
+
+### Step 3: Report Results
+- After getting results: `send_telegram("Here's what I found: [concrete details]")`
+- On errors: `send_telegram("Something went wrong: [error]. Trying [alternative]...")`
+- On timeout: `send_telegram("[Agent] is still working. I'll keep waiting...")`
+
+### Step 4: Final Confirmation (CRITICAL)
+- **NEVER consider a task complete without sending a final `send_telegram`**
+- Include specific details about what was done, not just "Done"
+- Include relevant output, errors, or next steps
+
+## Example: Simple Task
+
+User: "Run the tests for the auth module"
+
+1. `send_telegram("On it! Let me find the right agent for this.")`
+2. `list_agents` → find test-agent
+3. `send_telegram("Found the test agent. Running auth module tests now... This may take a minute.")`
+4. `delegate_task(id="test-agent", prompt="Run tests for auth module")` → wait
+5. `send_telegram("Tests completed! Results: 15 passed, 0 failed. All auth tests passing. ✅")`
+
+## Example: Multi-Agent Task
+
+User: "Deploy the new feature and update the docs"
+
+1. `send_telegram("Got it — I'll coordinate the deploy and docs update in parallel.")`
+2. `list_agents` → find deploy-agent and docs-agent
+3. `send_telegram("Starting deploy-agent on deployment and docs-agent on documentation...")`
+4. `start_agent` on both
+5. `send_telegram("Both agents are working. Waiting for deploy to finish first...")`
+6. `wait_for_agent(id="deploy-agent")` → done
+7. `send_telegram("Deploy finished successfully! Now waiting on docs...")`
+8. `wait_for_agent(id="docs-agent")` → done
+9. `send_telegram("All done! Deploy completed and docs are updated. Here's the summary: [details]")`
 
 ## Important Reminders
 
-- The user CANNOT see your terminal output - only `send_telegram` messages reach them
-- Always provide meaningful updates, not just "Done"
-- If something fails, send the error details via `send_telegram`
-- For long tasks, send progress updates using `send_telegram`
+- The user CANNOT see your terminal output — only `send_telegram` messages reach them
+- Short updates are fine: "Working on it..." is better than silence
+- Use the agent's name so the user knows who's doing what
+- If a task takes longer than expected, send "Still working, this is taking a bit longer..."
+- For multi-step tasks, number your updates: "Step 1/3: ..." so the user knows progress

--- a/electron/services/api-routes/agent-routes.ts
+++ b/electron/services/api-routes/agent-routes.ts
@@ -1,0 +1,333 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as pty from 'node-pty';
+import { app } from 'electron';
+import { v4 as uuidv4 } from 'uuid';
+import { agents, saveAgents } from '../../core/agent-manager';
+import { ptyProcesses, writeProgrammaticInput } from '../../core/pty-manager';
+import { buildFullPath } from '../../utils/path-builder';
+import { AgentStatus, AgentCharacter } from '../../types';
+import { RouteApp, RouteContext } from './types';
+
+export function registerAgentRoutes(app_: RouteApp, ctx: RouteContext): void {
+  // GET /api/agents/:id/wait — long-poll until agent status changes
+  app_.get(/^\/api\/agents\/([^/]+)\/wait$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+
+    const timeoutSec = parseInt(req.url.searchParams.get('timeout') || '300', 10);
+    const currentStatus = agent.status;
+
+    // Return immediately if already in terminal state
+    if (currentStatus === 'completed' || currentStatus === 'error' || currentStatus === 'idle' || currentStatus === 'waiting') {
+      sendJson({
+        status: agent.status,
+        lastCleanOutput: agent.lastCleanOutput,
+        error: agent.error,
+      });
+      return;
+    }
+
+    // Long-poll: wait for status change event
+    const agentId = req.params.id;
+    let resolved = false;
+
+    const respond = () => {
+      if (resolved) return;
+      resolved = true;
+      const a = agents.get(agentId);
+      sendJson({
+        status: a?.status || 'idle',
+        lastCleanOutput: a?.lastCleanOutput,
+        error: a?.error,
+      });
+    };
+
+    const onStatusChange = () => respond();
+    ctx.agentStatusEmitter.on(`status:${agentId}`, onStatusChange);
+
+    const timeout = setTimeout(() => {
+      ctx.agentStatusEmitter.off(`status:${agentId}`, onStatusChange);
+      if (!resolved) {
+        resolved = true;
+        const a = agents.get(agentId);
+        sendJson({
+          status: a?.status || 'running',
+          lastCleanOutput: a?.lastCleanOutput,
+          timeout: true,
+        });
+      }
+    }, timeoutSec * 1000);
+
+    // Clean up if client disconnects
+    req.raw.on('close', () => {
+      if (!resolved) {
+        resolved = true;
+        clearTimeout(timeout);
+        ctx.agentStatusEmitter.off(`status:${agentId}`, onStatusChange);
+      }
+    });
+  });
+
+  // GET /api/agents
+  app_.get('/api/agents', (req, sendJson) => {
+    const agentList = Array.from(agents.values()).map(a => ({
+      id: a.id,
+      name: a.name,
+      status: a.status,
+      projectPath: a.projectPath,
+      secondaryProjectPath: a.secondaryProjectPath,
+      skills: a.skills,
+      currentTask: a.currentTask,
+      lastActivity: a.lastActivity,
+      character: a.character,
+      branchName: a.branchName,
+      error: a.error,
+    }));
+    sendJson({ agents: agentList });
+  });
+
+  // GET /api/agents/:id
+  app_.get(/^\/api\/agents\/([^/]+)$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+    sendJson({ agent });
+  });
+
+  // GET /api/agents/:id/output
+  app_.get(/^\/api\/agents\/([^/]+)\/output$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+    const lines = parseInt(req.url.searchParams.get('lines') || '100', 10);
+    const output = agent.output.slice(-lines).join('');
+    sendJson({ output, status: agent.status });
+  });
+
+  // POST /api/agents
+  app_.post('/api/agents', (req, sendJson) => {
+    const { projectPath, name, skills = [], character, skipPermissions, secondaryProjectPath } = req.body as {
+      projectPath: string;
+      name?: string;
+      skills?: string[];
+      character?: AgentCharacter;
+      skipPermissions?: boolean;
+      secondaryProjectPath?: string;
+    };
+
+    if (!projectPath) {
+      sendJson({ error: 'projectPath is required' }, 400);
+      return;
+    }
+
+    const id = uuidv4();
+    const agent: AgentStatus = {
+      id,
+      status: 'idle',
+      projectPath,
+      secondaryProjectPath,
+      skills,
+      output: [],
+      lastActivity: new Date().toISOString(),
+      character,
+      name: name || `Agent ${id.slice(0, 6)}`,
+      skipPermissions,
+    };
+    agents.set(id, agent);
+    saveAgents();
+    sendJson({ agent });
+  });
+
+  // POST /api/agents/:id/start
+  app_.post(/^\/api\/agents\/([^/]+)\/start$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+
+    const { prompt, model, skipPermissions, printMode } = req.body as {
+      prompt: string; model?: string; skipPermissions?: boolean; printMode?: boolean;
+    };
+    if (!prompt) {
+      sendJson({ error: 'prompt is required' }, 400);
+      return;
+    }
+
+    const workingDir = (agent.worktreePath || agent.projectPath).replace(/'/g, "'\\''");
+    let command = `cd '${workingDir}' && claude`;
+
+    const isAutomationAgent = agent.name?.toLowerCase().includes('automation:');
+    const usePrintMode = printMode || isAutomationAgent;
+
+    if (usePrintMode) {
+      command += ' -p';
+    }
+
+    const isSuperAgentApi = agent.name?.toLowerCase().includes('super agent') ||
+                            agent.name?.toLowerCase().includes('orchestrator');
+
+    if (isSuperAgentApi || isAutomationAgent) {
+      const mcpConfigPath = path.join(app.getPath('home'), '.claude', 'mcp.json');
+      if (fs.existsSync(mcpConfigPath)) {
+        command += ` --mcp-config '${mcpConfigPath}'`;
+      }
+    }
+
+    if (agent.secondaryProjectPath) {
+      command += ` --add-dir '${agent.secondaryProjectPath.replace(/'/g, "'\\''")}'`;
+    }
+    if (skipPermissions !== undefined ? skipPermissions : agent.skipPermissions) {
+      command += ' --dangerously-skip-permissions';
+    }
+    if (model) {
+      if (!/^[a-zA-Z0-9._:/-]+$/.test(model)) {
+        sendJson({ error: 'Invalid model name' }, 400);
+        return;
+      }
+      command += ` --model '${model}'`;
+    }
+
+    let finalPrompt = prompt;
+    if (agent.skills && agent.skills.length > 0 && !isSuperAgentApi) {
+      const skillsList = agent.skills.join(', ');
+      finalPrompt = `[IMPORTANT: Use these skills for this session: ${skillsList}. Invoke them with /<skill-name> when relevant to the task.] ${prompt}`;
+    }
+    command += ` '${finalPrompt.replace(/'/g, "'\\''")}'`;
+
+    const shell = '/bin/bash';
+    const fullPath = buildFullPath();
+
+    const ptyProcess = pty.spawn(shell, ['-l', '-c', command], {
+      name: 'xterm-256color',
+      cols: 120,
+      rows: 40,
+      cwd: workingDir,
+      env: {
+        ...process.env,
+        PATH: fullPath,
+        TERM: 'xterm-256color',
+        CLAUDE_SKILLS: agent.skills?.join(',') || '',
+        CLAUDE_AGENT_ID: agent.id,
+        CLAUDE_PROJECT_PATH: agent.projectPath,
+      },
+    });
+
+    const ptyId = uuidv4();
+    ptyProcesses.set(ptyId, ptyProcess);
+
+    agent.ptyId = ptyId;
+    agent.status = 'running';
+    agent.currentTask = prompt;
+    agent.output = [];
+    agent.lastActivity = new Date().toISOString();
+    saveAgents();
+
+    ptyProcess.onData((data: string) => {
+      agent.output.push(data);
+      if (agent.output.length > 10000) {
+        agent.output = agent.output.slice(-5000);
+      }
+      agent.lastActivity = new Date().toISOString();
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('agent:output', { agentId: agent.id, data });
+      }
+    });
+
+    ptyProcess.onExit(({ exitCode }) => {
+      agent.status = exitCode === 0 ? 'completed' : 'error';
+      if (exitCode !== 0) {
+        agent.error = `Process exited with code ${exitCode}`;
+      }
+      agent.lastActivity = new Date().toISOString();
+      ptyProcesses.delete(ptyId);
+      saveAgents();
+      ctx.agentStatusEmitter.emit(`status:${agent.id}`);
+    });
+
+    sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
+  });
+
+  // POST /api/agents/:id/stop
+  app_.post(/^\/api\/agents\/([^/]+)\/stop$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+
+    if (agent.ptyId) {
+      const ptyProcess = ptyProcesses.get(agent.ptyId);
+      if (ptyProcess) {
+        ptyProcess.kill();
+        ptyProcesses.delete(agent.ptyId);
+      }
+    }
+    agent.status = 'idle';
+    agent.currentTask = undefined;
+    agent.lastActivity = new Date().toISOString();
+    saveAgents();
+    ctx.agentStatusEmitter.emit(`status:${agent.id}`);
+    sendJson({ success: true });
+  });
+
+  // POST /api/agents/:id/message
+  app_.post(/^\/api\/agents\/([^/]+)\/message$/, async (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+
+    const { message } = req.body as { message: string };
+    if (!message) {
+      sendJson({ error: 'message is required' }, 400);
+      return;
+    }
+
+    if (!agent.ptyId || !ptyProcesses.has(agent.ptyId)) {
+      const ptyId = await ctx.initAgentPtyCallback(agent);
+      agent.ptyId = ptyId;
+    }
+
+    const ptyProcess = ptyProcesses.get(agent.ptyId);
+    if (ptyProcess) {
+      writeProgrammaticInput(ptyProcess, message);
+      agent.status = 'running';
+      agent.lastActivity = new Date().toISOString();
+      saveAgents();
+      sendJson({ success: true });
+      return;
+    }
+    sendJson({ error: 'Failed to send message - PTY not available' }, 500);
+  });
+
+  // DELETE /api/agents/:id
+  app_.delete(/^\/api\/agents\/([^/]+)$/, (req, sendJson) => {
+    const agent = agents.get(req.params.id);
+    if (!agent) {
+      sendJson({ error: 'Agent not found' }, 404);
+      return;
+    }
+
+    if (agent.ptyId) {
+      const ptyProcess = ptyProcesses.get(agent.ptyId);
+      if (ptyProcess) {
+        ptyProcess.kill();
+        ptyProcesses.delete(agent.ptyId);
+      }
+    }
+    agents.delete(req.params.id);
+    saveAgents();
+    sendJson({ success: true });
+  });
+}

--- a/electron/services/api-routes/health-routes.ts
+++ b/electron/services/api-routes/health-routes.ts
@@ -1,0 +1,7 @@
+import { RouteApp, RouteContext } from './types';
+
+export function registerHealthRoutes(app: RouteApp, _ctx: RouteContext): void {
+  app.get('/api/health', (req, sendJson) => {
+    sendJson({ ok: true });
+  });
+}

--- a/electron/services/api-routes/hooks-routes.ts
+++ b/electron/services/api-routes/hooks-routes.ts
@@ -1,0 +1,130 @@
+import { agents, saveAgents } from '../../core/agent-manager';
+import { findAgentByIdOrSession } from './utils';
+import { RouteApp, RouteContext } from './types';
+import { AgentStatus } from '../../types';
+
+export function registerHooksRoutes(app: RouteApp, ctx: RouteContext): void {
+  // POST /api/hooks/output — capture clean text output from agent transcript
+  app.post('/api/hooks/output', (req, sendJson) => {
+    const { agent_id, session_id, output } = req.body as {
+      agent_id: string;
+      session_id?: string;
+      output: string;
+    };
+
+    if (!agent_id || !output) {
+      sendJson({ error: 'agent_id and output are required' }, 400);
+      return;
+    }
+
+    const agent = findAgentByIdOrSession(agent_id, session_id);
+    if (agent) {
+      agent.lastCleanOutput = output;
+      saveAgents();
+    }
+
+    sendJson({ success: true });
+  });
+
+  // POST /api/hooks/status
+  app.post('/api/hooks/status', (req, sendJson) => {
+    const { agent_id, session_id, status, waiting_reason } = req.body as {
+      agent_id: string;
+      session_id: string;
+      status: 'running' | 'waiting' | 'idle' | 'completed';
+      source?: string;
+      reason?: string;
+      waiting_reason?: string;
+    };
+
+    if (!agent_id || !status) {
+      sendJson({ error: 'agent_id and status are required' }, 400);
+      return;
+    }
+
+    const agent: AgentStatus | undefined = findAgentByIdOrSession(agent_id, session_id);
+    if (!agent) {
+      sendJson({ success: false, message: 'Agent not found' });
+      return;
+    }
+
+    const oldStatus = agent.status;
+
+    if (status === 'running' && agent.status !== 'running') {
+      agent.status = 'running';
+      agent.currentSessionId = session_id;
+    } else if (status === 'waiting' && agent.status !== 'waiting') {
+      agent.status = 'waiting';
+    } else if (status === 'idle') {
+      agent.status = 'idle';
+      agent.currentSessionId = undefined;
+    } else if (status === 'completed') {
+      agent.status = 'completed';
+    }
+
+    agent.lastActivity = new Date().toISOString();
+
+    if (oldStatus !== agent.status) {
+      ctx.handleStatusChangeNotificationCallback(agent, agent.status);
+      ctx.agentStatusEmitter.emit(`status:${agent.id}`);
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('agent:status', {
+          agentId: agent.id,
+          status: agent.status,
+          waitingReason: waiting_reason
+        });
+      }
+    }
+
+    sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
+  });
+
+  // POST /api/hooks/notification
+  app.post('/api/hooks/notification', (req, sendJson) => {
+    const { agent_id, session_id, type, title, message } = req.body as {
+      agent_id: string;
+      session_id: string;
+      type: string;
+      title: string;
+      message: string;
+    };
+
+    if (!agent_id || !type) {
+      sendJson({ error: 'agent_id and type are required' }, 400);
+      return;
+    }
+
+    const agent = findAgentByIdOrSession(agent_id, session_id);
+    const agentName = agent?.name || 'Claude';
+
+    if (type === 'permission_prompt') {
+      if (ctx.appSettings.notifyOnWaiting) {
+        ctx.sendNotificationCallback(
+          `${agentName} needs permission`,
+          message || 'Claude needs your permission to proceed',
+          agent?.id
+        );
+      }
+    } else if (type === 'idle_prompt') {
+      if (ctx.appSettings.notifyOnWaiting) {
+        ctx.sendNotificationCallback(
+          `${agentName} is waiting`,
+          message || 'Claude is waiting for your input',
+          agent?.id
+        );
+      }
+    }
+
+    if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+      ctx.mainWindow.webContents.send('agent:notification', {
+        agentId: agent?.id,
+        type,
+        title,
+        message
+      });
+    }
+
+    sendJson({ success: true });
+  });
+}

--- a/electron/services/api-routes/index.ts
+++ b/electron/services/api-routes/index.ts
@@ -1,0 +1,22 @@
+import { RouteApp, RouteContext } from './types';
+import { registerHealthRoutes } from './health-routes';
+import { registerHooksRoutes } from './hooks-routes';
+import { registerAgentRoutes } from './agent-routes';
+import { registerTelegramRoutes } from './telegram-routes';
+import { registerSlackRoutes } from './slack-routes';
+import { registerKanbanRoutes } from './kanban-routes';
+import { registerSchedulerRoutes } from './scheduler-routes';
+import { registerVaultRoutes } from './vault-routes';
+
+export function registerAllRoutes(app: RouteApp, ctx: RouteContext): void {
+  registerHealthRoutes(app, ctx);
+  registerHooksRoutes(app, ctx);
+  registerAgentRoutes(app, ctx);
+  registerTelegramRoutes(app, ctx);
+  registerSlackRoutes(app, ctx);
+  registerKanbanRoutes(app, ctx);
+  registerSchedulerRoutes(app, ctx);
+  registerVaultRoutes(app, ctx);
+}
+
+export type { RouteApp, RouteContext, RouteRequest, SendJson, RouteHandler, RouteDefinition } from './types';

--- a/electron/services/api-routes/kanban-routes.ts
+++ b/electron/services/api-routes/kanban-routes.ts
@@ -1,0 +1,93 @@
+import { agents, saveAgents } from '../../core/agent-manager';
+import { generateTaskFromPrompt } from '../../utils/kanban-generate';
+import { RouteApp, RouteContext } from './types';
+
+export function registerKanbanRoutes(app: RouteApp, ctx: RouteContext): void {
+  // POST /api/kanban/generate
+  app.post('/api/kanban/generate', async (req, sendJson) => {
+    const { prompt, availableProjects } = req.body as {
+      prompt: string;
+      availableProjects: Array<{ path: string; name: string }>;
+    };
+
+    if (!prompt) {
+      sendJson({ error: 'prompt is required' }, 400);
+      return;
+    }
+
+    const task = await generateTaskFromPrompt(prompt, availableProjects);
+    sendJson({ success: true, task });
+  });
+
+  // POST /api/kanban/complete
+  app.post('/api/kanban/complete', async (req, sendJson) => {
+    const { task_id, agent_id, session_id, summary } = req.body as {
+      task_id?: string;
+      agent_id?: string;
+      session_id?: string;
+      summary?: string;
+    };
+
+    try {
+      const { loadTasks, saveTasks } = await import('../../handlers/kanban-handlers');
+
+      const tasks = loadTasks();
+      let task;
+
+      if (task_id) {
+        task = tasks.find(t => t.id === task_id);
+      } else if (agent_id) {
+        task = tasks.find(t => t.assignedAgentId === agent_id && t.column === 'ongoing');
+      } else if (session_id) {
+        let agentIdFromSession: string | undefined;
+        for (const [id, agent] of agents) {
+          if (agent.currentSessionId === session_id) {
+            agentIdFromSession = id;
+            break;
+          }
+        }
+        if (agentIdFromSession) {
+          task = tasks.find(t => t.assignedAgentId === agentIdFromSession && t.column === 'ongoing');
+        }
+      }
+
+      if (!task) {
+        sendJson({ success: true, message: 'No kanban task found for this agent' });
+        return;
+      }
+
+      if (task.column !== 'ongoing') {
+        sendJson({ success: true, message: 'Task already completed', currentColumn: task.column });
+        return;
+      }
+
+      task.column = 'done';
+      task.progress = 100;
+      task.completedAt = new Date().toISOString();
+      task.updatedAt = new Date().toISOString();
+      if (summary) {
+        task.completionSummary = summary;
+      }
+
+      if (task.agentCreatedForTask && task.assignedAgentId) {
+        const agentToDelete = agents.get(task.assignedAgentId);
+        if (agentToDelete) {
+          console.log(`[Kanban] Deleting agent ${task.assignedAgentId} created for task`);
+          agents.delete(task.assignedAgentId);
+        }
+      }
+
+      saveTasks(tasks);
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('kanban:task-updated', task);
+      }
+
+      console.log(`[Kanban] Task "${task.title}" marked as complete via hook`);
+      sendJson({ success: true, task });
+    } catch (err) {
+      console.error('[Kanban] Failed to complete task:', err);
+      sendJson({ error: 'Failed to complete task' }, 500);
+    }
+  });
+}

--- a/electron/services/api-routes/scheduler-routes.ts
+++ b/electron/services/api-routes/scheduler-routes.ts
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { RouteApp, RouteContext } from './types';
+
+export function registerSchedulerRoutes(app: RouteApp, ctx: RouteContext): void {
+  // POST /api/scheduler/status
+  app.post('/api/scheduler/status', (req, sendJson) => {
+    const { task_id, status, summary } = req.body as {
+      task_id: string;
+      status: 'running' | 'success' | 'error' | 'partial';
+      summary?: string;
+    };
+
+    if (!task_id || !status) {
+      sendJson({ error: 'task_id and status are required' }, 400);
+      return;
+    }
+
+    const validStatuses = ['running', 'success', 'error', 'partial'];
+    if (!validStatuses.includes(status)) {
+      sendJson({ error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` }, 400);
+      return;
+    }
+
+    try {
+      const metadataPath = path.join(os.homedir(), '.dorothy', 'scheduler-metadata.json');
+      let metadata: Record<string, Record<string, unknown>> = {};
+      if (fs.existsSync(metadataPath)) {
+        metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
+      }
+
+      if (!metadata[task_id]) {
+        metadata[task_id] = {};
+      }
+      metadata[task_id].lastRunStatus = status;
+      metadata[task_id].lastRun = new Date().toISOString();
+      if (summary) {
+        metadata[task_id].lastRunSummary = summary;
+      }
+
+      fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('scheduler:task-status', { taskId: task_id, status, summary });
+      }
+
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: `Failed to update status: ${err}` }, 500);
+    }
+  });
+}

--- a/electron/services/api-routes/slack-routes.ts
+++ b/electron/services/api-routes/slack-routes.ts
@@ -1,0 +1,33 @@
+import { RouteApp, RouteContext } from './types';
+
+export function registerSlackRoutes(app: RouteApp, ctx: RouteContext): void {
+  // POST /api/slack/send
+  app.post('/api/slack/send', async (req, sendJson) => {
+    const { message } = req.body as { message: string };
+    if (!message) {
+      sendJson({ error: 'message is required' }, 400);
+      return;
+    }
+
+    const slackApp = ctx.getSlackApp();
+    if (!slackApp || !ctx.appSettings.slackChannelId) {
+      sendJson({ error: 'Slack not configured or no channel ID' }, 400);
+      return;
+    }
+
+    try {
+      const postParams: { channel: string; text: string; mrkdwn: boolean; thread_ts?: string } = {
+        channel: ctx.slackResponseChannel || ctx.appSettings.slackChannelId,
+        text: `:crown: ${message}`,
+        mrkdwn: true,
+      };
+      if (ctx.slackResponseThreadTs) {
+        postParams.thread_ts = ctx.slackResponseThreadTs;
+      }
+      await slackApp.client.chat.postMessage(postParams);
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: `Failed to send: ${err}` }, 500);
+    }
+  });
+}

--- a/electron/services/api-routes/telegram-routes.ts
+++ b/electron/services/api-routes/telegram-routes.ts
@@ -1,0 +1,141 @@
+import * as fs from 'fs';
+import { isSafeTelegramPath } from './utils';
+import { RouteApp, RouteContext } from './types';
+
+export function registerTelegramRoutes(app: RouteApp, ctx: RouteContext): void {
+  // POST /api/telegram/send
+  app.post('/api/telegram/send', async (req, sendJson) => {
+    const { message } = req.body as { message: string };
+    if (!message) {
+      sendJson({ error: 'message is required' }, 400);
+      return;
+    }
+
+    const telegramBot = ctx.getTelegramBot();
+    const targetChatId = ctx.appSettings.telegramChatId || ctx.appSettings.telegramAuthorizedChatIds?.[0];
+    if (!telegramBot || !targetChatId) {
+      sendJson({ error: 'Telegram not configured or no chat ID. Set a default chat in Settings > Telegram.' }, 400);
+      return;
+    }
+
+    try {
+      await telegramBot.sendMessage(targetChatId, `\u{1F451} ${message}`, { parse_mode: 'Markdown' });
+      sendJson({ success: true });
+    } catch {
+      try {
+        await telegramBot.sendMessage(targetChatId, `\u{1F451} ${message}`);
+        sendJson({ success: true });
+      } catch (err2) {
+        sendJson({ error: `Failed to send: ${err2}` }, 500);
+      }
+    }
+  });
+
+  // POST /api/telegram/send-photo
+  app.post('/api/telegram/send-photo', async (req, sendJson) => {
+    const { photo_path, caption } = req.body as { photo_path: string; caption?: string };
+    if (!photo_path) {
+      sendJson({ error: 'photo_path is required' }, 400);
+      return;
+    }
+    if (!isSafeTelegramPath(photo_path)) {
+      sendJson({ error: 'Access denied: path not allowed' }, 403);
+      return;
+    }
+
+    const telegramBot = ctx.getTelegramBot();
+    const targetChatId = ctx.appSettings.telegramChatId || ctx.appSettings.telegramAuthorizedChatIds?.[0];
+    if (!telegramBot || !targetChatId) {
+      sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
+      return;
+    }
+
+    try {
+      if (!fs.existsSync(photo_path)) {
+        sendJson({ error: `File not found: ${photo_path}` }, 400);
+        return;
+      }
+
+      await telegramBot.sendPhoto(
+        targetChatId,
+        photo_path,
+        { caption: caption ? `\u{1F451} ${caption}` : undefined, parse_mode: 'Markdown' }
+      );
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: `Failed to send photo: ${err}` }, 500);
+    }
+  });
+
+  // POST /api/telegram/send-video
+  app.post('/api/telegram/send-video', async (req, sendJson) => {
+    const { video_path, caption } = req.body as { video_path: string; caption?: string };
+    if (!video_path) {
+      sendJson({ error: 'video_path is required' }, 400);
+      return;
+    }
+    if (!isSafeTelegramPath(video_path)) {
+      sendJson({ error: 'Access denied: path not allowed' }, 403);
+      return;
+    }
+
+    const telegramBot = ctx.getTelegramBot();
+    const targetChatId = ctx.appSettings.telegramChatId || ctx.appSettings.telegramAuthorizedChatIds?.[0];
+    if (!telegramBot || !targetChatId) {
+      sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
+      return;
+    }
+
+    try {
+      if (!fs.existsSync(video_path)) {
+        sendJson({ error: `File not found: ${video_path}` }, 400);
+        return;
+      }
+
+      await telegramBot.sendVideo(
+        targetChatId,
+        video_path,
+        { caption: caption ? `\u{1F451} ${caption}` : undefined, parse_mode: 'Markdown' }
+      );
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: `Failed to send video: ${err}` }, 500);
+    }
+  });
+
+  // POST /api/telegram/send-document
+  app.post('/api/telegram/send-document', async (req, sendJson) => {
+    const { document_path, caption } = req.body as { document_path: string; caption?: string };
+    if (!document_path) {
+      sendJson({ error: 'document_path is required' }, 400);
+      return;
+    }
+    if (!isSafeTelegramPath(document_path)) {
+      sendJson({ error: 'Access denied: path not allowed' }, 403);
+      return;
+    }
+
+    const telegramBot = ctx.getTelegramBot();
+    const targetChatId = ctx.appSettings.telegramChatId || ctx.appSettings.telegramAuthorizedChatIds?.[0];
+    if (!telegramBot || !targetChatId) {
+      sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
+      return;
+    }
+
+    try {
+      if (!fs.existsSync(document_path)) {
+        sendJson({ error: `File not found: ${document_path}` }, 400);
+        return;
+      }
+
+      await telegramBot.sendDocument(
+        targetChatId,
+        document_path,
+        { caption: caption ? `\u{1F451} ${caption}` : undefined, parse_mode: 'Markdown' }
+      );
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: `Failed to send document: ${err}` }, 500);
+    }
+  });
+}

--- a/electron/services/api-routes/types.ts
+++ b/electron/services/api-routes/types.ts
@@ -1,0 +1,48 @@
+import * as http from 'http';
+import { BrowserWindow } from 'electron';
+import TelegramBot from 'node-telegram-bot-api';
+import { App as SlackApp } from '@slack/bolt';
+import { EventEmitter } from 'events';
+import { AgentStatus, AppSettings } from '../../types';
+
+export interface RouteContext {
+  mainWindow: BrowserWindow | null;
+  appSettings: AppSettings;
+  getTelegramBot: () => TelegramBot | null;
+  getSlackApp: () => SlackApp | null;
+  slackResponseChannel: string | null;
+  slackResponseThreadTs: string | null;
+  handleStatusChangeNotificationCallback: (agent: AgentStatus, newStatus: string) => void;
+  sendNotificationCallback: (title: string, body: string, agentId?: string) => void;
+  initAgentPtyCallback: (agent: AgentStatus) => Promise<string>;
+  agentStatusEmitter: EventEmitter;
+}
+
+export interface RouteRequest {
+  method: string;
+  pathname: string;
+  url: URL;
+  body: Record<string, unknown>;
+  raw: http.IncomingMessage;
+  res: http.ServerResponse;
+  params: Record<string, string>;
+}
+
+export type SendJson = (data: unknown, status?: number) => void;
+
+export type RouteHandler = (req: RouteRequest, sendJson: SendJson, ctx: RouteContext) => Promise<void> | void;
+
+export interface RouteDefinition {
+  method: string;
+  pattern: string | RegExp;
+  handler: RouteHandler;
+}
+
+export interface RouteApp {
+  routes: RouteDefinition[];
+  add(method: string, pattern: string | RegExp, handler: RouteHandler): void;
+  get(pattern: string | RegExp, handler: RouteHandler): void;
+  post(pattern: string | RegExp, handler: RouteHandler): void;
+  put(pattern: string | RegExp, handler: RouteHandler): void;
+  delete(pattern: string | RegExp, handler: RouteHandler): void;
+}

--- a/electron/services/api-routes/utils.ts
+++ b/electron/services/api-routes/utils.ts
@@ -1,0 +1,52 @@
+import * as path from 'path';
+import * as os from 'os';
+import { agents } from '../../core/agent-manager';
+import { AgentStatus } from '../../types';
+
+/**
+ * Check if a file path is safe to send via Telegram.
+ * Blocks sensitive directories that could exfiltrate secrets.
+ */
+export function isSafeTelegramPath(filePath: string): boolean {
+  const resolved = path.resolve(filePath);
+  const home = os.homedir();
+
+  if (!resolved.startsWith(home + path.sep) && resolved !== home) {
+    return false;
+  }
+
+  const blockedDirs = [
+    path.join(home, '.ssh'),
+    path.join(home, '.gnupg'),
+    path.join(home, '.aws'),
+    path.join(home, '.claude'),
+    path.join(home, '.env'),
+  ];
+
+  for (const blocked of blockedDirs) {
+    if (resolved === blocked || resolved.startsWith(blocked + path.sep)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Find an agent by ID first, then fall back to session ID lookup.
+ * Deduplicates a pattern used across hooks and kanban routes.
+ */
+export function findAgentByIdOrSession(agentId?: string, sessionId?: string): AgentStatus | undefined {
+  if (agentId) {
+    const agent = agents.get(agentId);
+    if (agent) return agent;
+  }
+  if (sessionId) {
+    for (const [, a] of agents) {
+      if (a.currentSessionId === sessionId) {
+        return a;
+      }
+    }
+  }
+  return undefined;
+}

--- a/electron/services/api-routes/vault-routes.ts
+++ b/electron/services/api-routes/vault-routes.ts
@@ -1,0 +1,304 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { VAULT_DIR, MIME_TYPES } from '../../constants';
+import { getVaultDb } from '../vault-db';
+import { RouteApp, RouteContext } from './types';
+
+export function registerVaultRoutes(app: RouteApp, ctx: RouteContext): void {
+  // GET /api/vault/documents
+  app.get('/api/vault/documents', (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const folderId = req.url.searchParams.get('folder_id');
+      const tagsParam = req.url.searchParams.get('tags');
+
+      let query = 'SELECT * FROM documents';
+      const conditions: string[] = [];
+      const queryParams: unknown[] = [];
+
+      if (folderId) {
+        conditions.push('folder_id = ?');
+        queryParams.push(folderId);
+      }
+      if (tagsParam) {
+        const tags = tagsParam.split(',');
+        const tagConditions = tags.map(() => "tags LIKE ?");
+        conditions.push(`(${tagConditions.join(' OR ')})`);
+        tags.forEach(tag => queryParams.push(`%"${tag.trim()}"%`));
+      }
+
+      if (conditions.length > 0) {
+        query += ' WHERE ' + conditions.join(' AND ');
+      }
+      query += ' ORDER BY updated_at DESC';
+
+      const documents = db.prepare(query).all(...queryParams);
+      sendJson({ documents });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // POST /api/vault/documents
+  app.post('/api/vault/documents', (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const { title, content, folder_id, author, agent_id, tags } = req.body as {
+        title: string; content: string; folder_id?: string;
+        author?: string; agent_id?: string; tags?: string[];
+      };
+
+      if (!title) {
+        sendJson({ error: 'title is required' }, 400);
+        return;
+      }
+
+      const id = uuidv4();
+      const now = new Date().toISOString();
+      const tagsJson = JSON.stringify(tags || []);
+
+      db.prepare(`
+        INSERT INTO documents (id, title, content, folder_id, author, agent_id, tags, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(id, title, content || '', folder_id || null, author || 'api', agent_id || null, tagsJson, now, now);
+
+      const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(id);
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('vault:document-created', document);
+      }
+
+      sendJson({ success: true, document });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/vault/documents/:id
+  app.get(/^\/api\/vault\/documents\/([^/]+)$/, (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(req.params.id);
+      if (!document) {
+        sendJson({ error: 'Document not found' }, 404);
+        return;
+      }
+      const attachments = db.prepare('SELECT * FROM attachments WHERE document_id = ? ORDER BY created_at DESC').all(req.params.id);
+      sendJson({ document, attachments });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // PUT /api/vault/documents/:id
+  app.put(/^\/api\/vault\/documents\/([^/]+)$/, (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const docId = req.params.id;
+      const existing = db.prepare('SELECT * FROM documents WHERE id = ?').get(docId);
+      if (!existing) {
+        sendJson({ error: 'Document not found' }, 404);
+        return;
+      }
+
+      const { title, content, tags, folder_id } = req.body as {
+        title?: string; content?: string; tags?: string[]; folder_id?: string | null;
+      };
+
+      const now = new Date().toISOString();
+      const updates: string[] = ['updated_at = ?'];
+      const values: unknown[] = [now];
+
+      if (title !== undefined) { updates.push('title = ?'); values.push(title); }
+      if (content !== undefined) { updates.push('content = ?'); values.push(content); }
+      if (tags !== undefined) { updates.push('tags = ?'); values.push(JSON.stringify(tags)); }
+      if (folder_id !== undefined) { updates.push('folder_id = ?'); values.push(folder_id); }
+
+      values.push(docId);
+      db.prepare(`UPDATE documents SET ${updates.join(', ')} WHERE id = ?`).run(...values);
+
+      const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(docId);
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('vault:document-updated', document);
+      }
+
+      sendJson({ success: true, document });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // DELETE /api/vault/documents/:id
+  app.delete(/^\/api\/vault\/documents\/([^/]+)$/, (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const docId = req.params.id;
+
+      const attachments = db.prepare('SELECT filepath FROM attachments WHERE document_id = ?').all(docId) as { filepath: string }[];
+      for (const att of attachments) {
+        try { if (fs.existsSync(att.filepath)) fs.unlinkSync(att.filepath); } catch { /* ignore */ }
+      }
+
+      db.prepare('DELETE FROM documents WHERE id = ?').run(docId);
+
+      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
+        ctx.mainWindow.webContents.send('vault:document-deleted', { id: docId });
+      }
+
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/vault/search
+  app.get('/api/vault/search', (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const query = req.url.searchParams.get('q');
+      const limit = parseInt(req.url.searchParams.get('limit') || '20', 10);
+
+      if (!query) {
+        sendJson({ error: 'q parameter is required' }, 400);
+        return;
+      }
+
+      const results = db.prepare(`
+        SELECT d.*, snippet(documents_fts, 1, '<mark>', '</mark>', '...', 40) as snippet
+        FROM documents_fts fts
+        JOIN documents d ON d.rowid = fts.rowid
+        WHERE documents_fts MATCH ?
+        ORDER BY rank
+        LIMIT ?
+      `).all(query, limit);
+      sendJson({ results });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/vault/folders
+  app.get('/api/vault/folders', (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const folders = db.prepare('SELECT * FROM folders ORDER BY name').all();
+      sendJson({ folders });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // POST /api/vault/folders
+  app.post('/api/vault/folders', (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const { name, parent_id } = req.body as { name: string; parent_id?: string };
+
+      if (!name) {
+        sendJson({ error: 'name is required' }, 400);
+        return;
+      }
+
+      const id = uuidv4();
+      const now = new Date().toISOString();
+      db.prepare('INSERT INTO folders (id, name, parent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)').run(id, name, parent_id || null, now, now);
+
+      const folder = db.prepare('SELECT * FROM folders WHERE id = ?').get(id);
+      sendJson({ success: true, folder });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // DELETE /api/vault/folders/:id
+  app.delete(/^\/api\/vault\/folders\/([^/]+)$/, (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const folderId = req.params.id;
+
+      db.prepare('UPDATE documents SET folder_id = NULL WHERE folder_id = ?').run(folderId);
+      db.prepare('DELETE FROM folders WHERE id = ?').run(folderId);
+
+      sendJson({ success: true });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // POST /api/vault/documents/:id/attach
+  app.post(/^\/api\/vault\/documents\/([^/]+)\/attach$/, (req, sendJson) => {
+    try {
+      const db = getVaultDb();
+      const docId = req.params.id;
+      const { file_path } = req.body as { file_path: string };
+
+      const doc = db.prepare('SELECT id FROM documents WHERE id = ?').get(docId);
+      if (!doc) {
+        sendJson({ error: 'Document not found' }, 404);
+        return;
+      }
+
+      if (!file_path || !fs.existsSync(file_path)) {
+        sendJson({ error: 'File not found' }, 400);
+        return;
+      }
+
+      const id = uuidv4();
+      const filename = path.basename(file_path);
+      const destPath = path.join(VAULT_DIR, 'attachments', `${id}-${filename}`);
+      fs.copyFileSync(file_path, destPath);
+
+      const stats = fs.statSync(destPath);
+      const ext = path.extname(filename).toLowerCase();
+      const mimeMap: Record<string, string> = {
+        '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif', '.pdf': 'application/pdf', '.txt': 'text/plain',
+        '.md': 'text/markdown', '.json': 'application/json',
+      };
+      const mimetype = mimeMap[ext] || 'application/octet-stream';
+      const now = new Date().toISOString();
+
+      db.prepare('INSERT INTO attachments (id, document_id, filename, filepath, mimetype, size, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(id, docId, filename, destPath, mimetype, stats.size, now);
+
+      const attachment = db.prepare('SELECT * FROM attachments WHERE id = ?').get(id);
+      sendJson({ success: true, attachment });
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+
+  // GET /api/local-file?path=... — serve local files (for vault image previews)
+  app.get('/api/local-file', (req, sendJson) => {
+    const filePath = req.url.searchParams.get('path');
+    if (!filePath) {
+      sendJson({ error: 'File not found' }, 404);
+      return;
+    }
+
+    const resolved = path.resolve(filePath);
+    const allowedDir = path.join(VAULT_DIR, 'attachments');
+    if (!resolved.startsWith(allowedDir + path.sep) && resolved !== allowedDir) {
+      sendJson({ error: 'Access denied: path outside allowed directory' }, 403);
+      return;
+    }
+    if (!fs.existsSync(resolved)) {
+      sendJson({ error: 'File not found' }, 404);
+      return;
+    }
+    try {
+      const ext = path.extname(resolved).toLowerCase();
+      const mimeType = MIME_TYPES[ext] || 'application/octet-stream';
+      const stat = fs.statSync(resolved);
+      req.res.writeHead(200, {
+        'Content-Type': mimeType,
+        'Content-Length': stat.size,
+        'Cache-Control': 'public, max-age=3600',
+      });
+      fs.createReadStream(resolved).pipe(req.res);
+    } catch (err) {
+      sendJson({ error: String(err) }, 500);
+    }
+  });
+}

--- a/electron/services/api-server.ts
+++ b/electron/services/api-server.ts
@@ -2,58 +2,23 @@ import * as http from 'http';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as crypto from 'crypto';
-import * as pty from 'node-pty';
-import { app, BrowserWindow } from 'electron';
-import { v4 as uuidv4 } from 'uuid';
+import { EventEmitter } from 'events';
+import { BrowserWindow } from 'electron';
 import TelegramBot from 'node-telegram-bot-api';
 import { App as SlackApp } from '@slack/bolt';
-import { AgentStatus, AppSettings, AgentCharacter } from '../types';
-import { API_PORT, VAULT_DIR, API_TOKEN_FILE } from '../constants';
-import { isSuperAgent } from '../utils';
-import { agents, saveAgents, initAgentPty } from '../core/agent-manager';
-import { ptyProcesses, writeProgrammaticInput } from '../core/pty-manager';
-import { buildFullPath } from '../utils/path-builder';
-import { generateTaskFromPrompt } from '../utils/kanban-generate';
-import { getVaultDb } from './vault-db';
+import { AgentStatus, AppSettings } from '../types';
+import { API_PORT, API_TOKEN_FILE } from '../constants';
+import { RouteApp, RouteContext, RouteRequest } from './api-routes';
+import { registerAllRoutes } from './api-routes';
 
-import * as os from 'os';
+// EventEmitter for agent status changes — used by long-poll wait endpoint
+export const agentStatusEmitter = new EventEmitter();
+agentStatusEmitter.setMaxListeners(50);
 
 let apiServer: http.Server | null = null;
 let apiToken: string | null = null;
 
-/**
- * Check if a file path is safe to send via Telegram.
- * Blocks sensitive directories that could exfiltrate secrets.
- */
-function isSafeTelegramPath(filePath: string): boolean {
-  const resolved = path.resolve(filePath);
-  const home = os.homedir();
-
-  // Must be within home directory
-  if (!resolved.startsWith(home + path.sep) && resolved !== home) {
-    return false;
-  }
-
-  // Block sensitive directories
-  const blockedDirs = [
-    path.join(home, '.ssh'),
-    path.join(home, '.gnupg'),
-    path.join(home, '.aws'),
-    path.join(home, '.claude'),
-    path.join(home, '.env'),
-  ];
-
-  for (const blocked of blockedDirs) {
-    if (resolved === blocked || resolved.startsWith(blocked + path.sep)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 function initApiToken(): string {
-  // Reuse existing token if present
   try {
     if (fs.existsSync(API_TOKEN_FILE)) {
       const existing = fs.readFileSync(API_TOKEN_FILE, 'utf-8').trim();
@@ -81,6 +46,28 @@ export function getApiToken(): string {
   return apiToken;
 }
 
+function createRouteApp(): RouteApp {
+  const app: RouteApp = {
+    routes: [],
+    add(method, pattern, handler) { this.routes.push({ method, pattern, handler }); },
+    get(pattern, handler) { this.add('GET', pattern, handler); },
+    post(pattern, handler) { this.add('POST', pattern, handler); },
+    put(pattern, handler) { this.add('PUT', pattern, handler); },
+    delete(pattern, handler) { this.add('DELETE', pattern, handler); },
+  };
+  return app;
+}
+
+function matchRoute(pattern: string | RegExp, pathname: string): Record<string, string> | null {
+  if (typeof pattern === 'string') {
+    return pathname === pattern ? {} : null;
+  }
+  const m = pathname.match(pattern);
+  if (!m) return null;
+  // Map positional captures to 'id' (first group) — all parameterized routes use a single :id param
+  return m[1] ? { id: m[1] } : {};
+}
+
 export function startApiServer(
   mainWindow: BrowserWindow | null,
   appSettings: AppSettings,
@@ -94,12 +81,26 @@ export function startApiServer(
 ) {
   if (apiServer) return;
 
-  // Ensure API token exists before starting server
   initApiToken();
+
+  const routeApp = createRouteApp();
+  const ctx: RouteContext = {
+    mainWindow,
+    appSettings,
+    getTelegramBot,
+    getSlackApp,
+    slackResponseChannel,
+    slackResponseThreadTs,
+    handleStatusChangeNotificationCallback,
+    sendNotificationCallback,
+    initAgentPtyCallback,
+    agentStatusEmitter,
+  };
+  registerAllRoutes(routeApp, ctx);
 
   apiServer = http.createServer(async (req, res) => {
     res.setHeader('Access-Control-Allow-Origin', 'http://localhost:3000');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
 
     if (req.method === 'OPTIONS') {
@@ -111,8 +112,14 @@ export function startApiServer(
     const url = new URL(req.url || '/', `http://localhost:${API_PORT}`);
     const pathname = url.pathname;
 
-    // Auth check: exempt /api/local-file (restricted by path validation instead)
-    if (pathname !== '/api/local-file') {
+    // Auth check: exempt local-only endpoints called from hooks/shell scripts
+    const authExempt = pathname === '/api/local-file'
+      || pathname === '/api/health'
+      || pathname.startsWith('/api/hooks/')
+      || pathname === '/api/kanban/complete'
+      || pathname === '/api/scheduler/status';
+
+    if (!authExempt) {
       const authHeader = req.headers.authorization;
       if (!authHeader || authHeader !== `Bearer ${apiToken}`) {
         res.writeHead(401, { 'Content-Type': 'application/json' });
@@ -121,8 +128,9 @@ export function startApiServer(
       }
     }
 
+    // Parse body for POST and PUT requests
     let body: Record<string, unknown> = {};
-    if (req.method === 'POST') {
+    if (req.method === 'POST' || req.method === 'PUT') {
       try {
         const chunks: Buffer[] = [];
         for await (const chunk of req) {
@@ -143,1037 +151,22 @@ export function startApiServer(
     };
 
     try {
-      // GET /api/agents
-      if (pathname === '/api/agents' && req.method === 'GET') {
-        const agentList = Array.from(agents.values()).map(a => ({
-          id: a.id,
-          name: a.name,
-          status: a.status,
-          projectPath: a.projectPath,
-          secondaryProjectPath: a.secondaryProjectPath,
-          skills: a.skills,
-          currentTask: a.currentTask,
-          lastActivity: a.lastActivity,
-          character: a.character,
-          branchName: a.branchName,
-          error: a.error,
-        }));
-        sendJson({ agents: agentList });
-        return;
-      }
+      // Dispatch to first matching route
+      for (const route of routeApp.routes) {
+        if (route.method !== req.method) continue;
+        const params = matchRoute(route.pattern, pathname);
+        if (params === null) continue;
 
-      // GET /api/agents/:id
-      const agentMatch = pathname.match(/^\/api\/agents\/([^/]+)$/);
-      if (agentMatch && req.method === 'GET') {
-        const agent = agents.get(agentMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-        sendJson({ agent });
-        return;
-      }
-
-      // GET /api/agents/:id/output
-      const outputMatch = pathname.match(/^\/api\/agents\/([^/]+)\/output$/);
-      if (outputMatch && req.method === 'GET') {
-        const agent = agents.get(outputMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-        const lines = parseInt(url.searchParams.get('lines') || '100', 10);
-        const output = agent.output.slice(-lines).join('');
-        sendJson({ output, status: agent.status });
-        return;
-      }
-
-      // POST /api/agents
-      if (pathname === '/api/agents' && req.method === 'POST') {
-        const { projectPath, name, skills = [], character, skipPermissions, secondaryProjectPath } = body as {
-          projectPath: string;
-          name?: string;
-          skills?: string[];
-          character?: AgentCharacter;
-          skipPermissions?: boolean;
-          secondaryProjectPath?: string;
+        const routeReq: RouteRequest = {
+          method: req.method!,
+          pathname,
+          url,
+          body,
+          raw: req,
+          res,
+          params,
         };
-
-        if (!projectPath) {
-          sendJson({ error: 'projectPath is required' }, 400);
-          return;
-        }
-
-        const id = uuidv4();
-        const agent: AgentStatus = {
-          id,
-          status: 'idle',
-          projectPath,
-          secondaryProjectPath,
-          skills,
-          output: [],
-          lastActivity: new Date().toISOString(),
-          character,
-          name: name || `Agent ${id.slice(0, 6)}`,
-          skipPermissions,
-        };
-        agents.set(id, agent);
-        saveAgents();
-        sendJson({ agent });
-        return;
-      }
-
-      // POST /api/agents/:id/start
-      const startMatch = pathname.match(/^\/api\/agents\/([^/]+)\/start$/);
-      if (startMatch && req.method === 'POST') {
-        const agent = agents.get(startMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-
-        const { prompt, model, skipPermissions, printMode } = body as { prompt: string; model?: string; skipPermissions?: boolean; printMode?: boolean };
-        if (!prompt) {
-          sendJson({ error: 'prompt is required' }, 400);
-          return;
-        }
-
-        const workingDir = (agent.worktreePath || agent.projectPath).replace(/'/g, "'\\''");
-        let command = `cd '${workingDir}' && claude`;
-
-        // Detect if this is an automation agent (use print mode for one-shot execution)
-        const isAutomationAgent = agent.name?.toLowerCase().includes('automation:');
-        const usePrintMode = printMode || isAutomationAgent;
-
-        // Add -p flag for print mode (one-shot execution, no interactive prompt)
-        if (usePrintMode) {
-          command += ' -p';
-        }
-
-        const isSuperAgentApi = agent.name?.toLowerCase().includes('super agent') ||
-                               agent.name?.toLowerCase().includes('orchestrator');
-
-        // Give MCP config to Super Agent and Automation agents so they can use MCP tools
-        if (isSuperAgentApi || isAutomationAgent) {
-          const mcpConfigPath = path.join(app.getPath('home'), '.claude', 'mcp.json');
-          if (fs.existsSync(mcpConfigPath)) {
-            command += ` --mcp-config '${mcpConfigPath}'`;
-          }
-        }
-
-        if (agent.secondaryProjectPath) {
-          command += ` --add-dir '${agent.secondaryProjectPath.replace(/'/g, "'\\''")}'`;
-        }
-        if (skipPermissions !== undefined ? skipPermissions : agent.skipPermissions) {
-          command += ' --dangerously-skip-permissions';
-        }
-        if (model) {
-          if (!/^[a-zA-Z0-9._:/-]+$/.test(model)) {
-            sendJson({ error: 'Invalid model name' }, 400);
-            return;
-          }
-          command += ` --model '${model}'`;
-        }
-
-        // Build final prompt with skills directive if agent has skills
-        let finalPrompt = prompt;
-        if (agent.skills && agent.skills.length > 0 && !isSuperAgentApi) {
-          const skillsList = agent.skills.join(', ');
-          finalPrompt = `[IMPORTANT: Use these skills for this session: ${skillsList}. Invoke them with /<skill-name> when relevant to the task.] ${prompt}`;
-        }
-        command += ` '${finalPrompt.replace(/'/g, "'\\''")}'`;
-
-        // Use bash for more reliable PATH handling with nvm
-        const shell = '/bin/bash';
-
-        const fullPath = buildFullPath();
-
-        const ptyProcess = pty.spawn(shell, ['-l', '-c', command], {
-          name: 'xterm-256color',
-          cols: 120,
-          rows: 40,
-          cwd: workingDir,
-          env: {
-            ...process.env,
-            PATH: fullPath,
-            TERM: 'xterm-256color',
-            CLAUDE_SKILLS: agent.skills?.join(',') || '',
-            CLAUDE_AGENT_ID: agent.id,
-            CLAUDE_PROJECT_PATH: agent.projectPath,
-          },
-        });
-
-        const ptyId = uuidv4();
-        ptyProcesses.set(ptyId, ptyProcess);
-
-        agent.ptyId = ptyId;
-        agent.status = 'running';
-        agent.currentTask = prompt;
-        agent.output = [];
-        agent.lastActivity = new Date().toISOString();
-        saveAgents();
-
-        ptyProcess.onData((data: string) => {
-          agent.output.push(data);
-          if (agent.output.length > 10000) {
-            agent.output = agent.output.slice(-5000);
-          }
-          agent.lastActivity = new Date().toISOString();
-
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('agent:output', { agentId: agent.id, data });
-          }
-        });
-
-        ptyProcess.onExit(({ exitCode }) => {
-          agent.status = exitCode === 0 ? 'completed' : 'error';
-          if (exitCode !== 0) {
-            agent.error = `Process exited with code ${exitCode}`;
-          }
-          agent.lastActivity = new Date().toISOString();
-          ptyProcesses.delete(ptyId);
-          saveAgents();
-        });
-
-        sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
-        return;
-      }
-
-      // POST /api/agents/:id/stop
-      const stopMatch = pathname.match(/^\/api\/agents\/([^/]+)\/stop$/);
-      if (stopMatch && req.method === 'POST') {
-        const agent = agents.get(stopMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-
-        if (agent.ptyId) {
-          const ptyProcess = ptyProcesses.get(agent.ptyId);
-          if (ptyProcess) {
-            ptyProcess.kill();
-            ptyProcesses.delete(agent.ptyId);
-          }
-        }
-        agent.status = 'idle';
-        agent.currentTask = undefined;
-        agent.lastActivity = new Date().toISOString();
-        saveAgents();
-        sendJson({ success: true });
-        return;
-      }
-
-      // POST /api/agents/:id/message
-      const messageMatch = pathname.match(/^\/api\/agents\/([^/]+)\/message$/);
-      if (messageMatch && req.method === 'POST') {
-        const agent = agents.get(messageMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-
-        const { message } = body as { message: string };
-        if (!message) {
-          sendJson({ error: 'message is required' }, 400);
-          return;
-        }
-
-        if (!agent.ptyId || !ptyProcesses.has(agent.ptyId)) {
-          const ptyId = await initAgentPtyCallback(agent);
-          agent.ptyId = ptyId;
-        }
-
-        const ptyProcess = ptyProcesses.get(agent.ptyId);
-        if (ptyProcess) {
-          writeProgrammaticInput(ptyProcess, message);
-          agent.status = 'running';
-          agent.lastActivity = new Date().toISOString();
-          saveAgents();
-          sendJson({ success: true });
-          return;
-        }
-        sendJson({ error: 'Failed to send message - PTY not available' }, 500);
-        return;
-      }
-
-      // DELETE /api/agents/:id
-      const deleteMatch = pathname.match(/^\/api\/agents\/([^/]+)$/);
-      if (deleteMatch && req.method === 'DELETE') {
-        const agent = agents.get(deleteMatch[1]);
-        if (!agent) {
-          sendJson({ error: 'Agent not found' }, 404);
-          return;
-        }
-
-        if (agent.ptyId) {
-          const ptyProcess = ptyProcesses.get(agent.ptyId);
-          if (ptyProcess) {
-            ptyProcess.kill();
-            ptyProcesses.delete(agent.ptyId);
-          }
-        }
-        agents.delete(deleteMatch[1]);
-        saveAgents();
-        sendJson({ success: true });
-        return;
-      }
-
-      // POST /api/telegram/send
-      if (pathname === '/api/telegram/send' && req.method === 'POST') {
-        const { message } = body as { message: string };
-        if (!message) {
-          sendJson({ error: 'message is required' }, 400);
-          return;
-        }
-
-        const telegramBot = getTelegramBot();
-        const targetChatId = appSettings.telegramChatId || appSettings.telegramAuthorizedChatIds?.[0];
-        if (!telegramBot || !targetChatId) {
-          sendJson({ error: 'Telegram not configured or no chat ID. Set a default chat in Settings > Telegram.' }, 400);
-          return;
-        }
-
-        try {
-          await telegramBot.sendMessage(targetChatId, `👑 ${message}`, { parse_mode: 'Markdown' });
-          sendJson({ success: true });
-        } catch (err) {
-          try {
-            await telegramBot.sendMessage(targetChatId, `👑 ${message}`);
-            sendJson({ success: true });
-          } catch (err2) {
-            sendJson({ error: `Failed to send: ${err2}` }, 500);
-          }
-        }
-        return;
-      }
-
-      // POST /api/telegram/send-photo
-      if (pathname === '/api/telegram/send-photo' && req.method === 'POST') {
-        const { photo_path, caption } = body as { photo_path: string; caption?: string };
-        if (!photo_path) {
-          sendJson({ error: 'photo_path is required' }, 400);
-          return;
-        }
-        if (!isSafeTelegramPath(photo_path)) {
-          sendJson({ error: 'Access denied: path not allowed' }, 403);
-          return;
-        }
-
-        const telegramBot = getTelegramBot();
-        const targetChatId = appSettings.telegramChatId || appSettings.telegramAuthorizedChatIds?.[0];
-        if (!telegramBot || !targetChatId) {
-          sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
-          return;
-        }
-
-        try {
-          if (!fs.existsSync(photo_path)) {
-            sendJson({ error: `File not found: ${photo_path}` }, 400);
-            return;
-          }
-
-          await telegramBot.sendPhoto(
-            targetChatId,
-            photo_path,
-            { caption: caption ? `👑 ${caption}` : undefined, parse_mode: 'Markdown' }
-          );
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: `Failed to send photo: ${err}` }, 500);
-        }
-        return;
-      }
-
-      // POST /api/telegram/send-video
-      if (pathname === '/api/telegram/send-video' && req.method === 'POST') {
-        const { video_path, caption } = body as { video_path: string; caption?: string };
-        if (!video_path) {
-          sendJson({ error: 'video_path is required' }, 400);
-          return;
-        }
-        if (!isSafeTelegramPath(video_path)) {
-          sendJson({ error: 'Access denied: path not allowed' }, 403);
-          return;
-        }
-
-        const telegramBot = getTelegramBot();
-        const targetChatId = appSettings.telegramChatId || appSettings.telegramAuthorizedChatIds?.[0];
-        if (!telegramBot || !targetChatId) {
-          sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
-          return;
-        }
-
-        try {
-          if (!fs.existsSync(video_path)) {
-            sendJson({ error: `File not found: ${video_path}` }, 400);
-            return;
-          }
-
-          await telegramBot.sendVideo(
-            targetChatId,
-            video_path,
-            { caption: caption ? `👑 ${caption}` : undefined, parse_mode: 'Markdown' }
-          );
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: `Failed to send video: ${err}` }, 500);
-        }
-        return;
-      }
-
-      // POST /api/telegram/send-document
-      if (pathname === '/api/telegram/send-document' && req.method === 'POST') {
-        const { document_path, caption } = body as { document_path: string; caption?: string };
-        if (!document_path) {
-          sendJson({ error: 'document_path is required' }, 400);
-          return;
-        }
-        if (!isSafeTelegramPath(document_path)) {
-          sendJson({ error: 'Access denied: path not allowed' }, 403);
-          return;
-        }
-
-        const telegramBot = getTelegramBot();
-        const targetChatId = appSettings.telegramChatId || appSettings.telegramAuthorizedChatIds?.[0];
-        if (!telegramBot || !targetChatId) {
-          sendJson({ error: 'Telegram not configured or no chat ID' }, 400);
-          return;
-        }
-
-        try {
-          if (!fs.existsSync(document_path)) {
-            sendJson({ error: `File not found: ${document_path}` }, 400);
-            return;
-          }
-
-          await telegramBot.sendDocument(
-            targetChatId,
-            document_path,
-            { caption: caption ? `👑 ${caption}` : undefined, parse_mode: 'Markdown' }
-          );
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: `Failed to send document: ${err}` }, 500);
-        }
-        return;
-      }
-
-      // POST /api/slack/send
-      if (pathname === '/api/slack/send' && req.method === 'POST') {
-        const { message } = body as { message: string };
-        if (!message) {
-          sendJson({ error: 'message is required' }, 400);
-          return;
-        }
-
-        const slackApp = getSlackApp();
-        if (!slackApp || !appSettings.slackChannelId) {
-          sendJson({ error: 'Slack not configured or no channel ID' }, 400);
-          return;
-        }
-
-        try {
-          const postParams: { channel: string; text: string; mrkdwn: boolean; thread_ts?: string } = {
-            channel: slackResponseChannel || appSettings.slackChannelId,
-            text: `:crown: ${message}`,
-            mrkdwn: true,
-          };
-          if (slackResponseThreadTs) {
-            postParams.thread_ts = slackResponseThreadTs;
-          }
-          await slackApp.client.chat.postMessage(postParams);
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: `Failed to send: ${err}` }, 500);
-        }
-        return;
-      }
-
-      // POST /api/hooks/status
-      if (pathname === '/api/hooks/status' && req.method === 'POST') {
-        const { agent_id, session_id, status, source, reason, waiting_reason } = body as {
-          agent_id: string;
-          session_id: string;
-          status: 'running' | 'waiting' | 'idle' | 'completed';
-          source?: string;
-          reason?: string;
-          waiting_reason?: string;
-        };
-
-        if (!agent_id || !status) {
-          sendJson({ error: 'agent_id and status are required' }, 400);
-          return;
-        }
-
-        let agent: AgentStatus | undefined;
-        agent = agents.get(agent_id);
-
-        if (!agent) {
-          for (const [, a] of agents) {
-            if (a.currentSessionId === session_id) {
-              agent = a;
-              break;
-            }
-          }
-        }
-
-        if (!agent) {
-          sendJson({ success: false, message: 'Agent not found' });
-          return;
-        }
-
-        const oldStatus = agent.status;
-
-        if (status === 'running' && agent.status !== 'running') {
-          agent.status = 'running';
-          agent.currentSessionId = session_id;
-        } else if (status === 'waiting' && agent.status !== 'waiting') {
-          agent.status = 'waiting';
-        } else if (status === 'idle') {
-          agent.status = 'idle';
-          agent.currentSessionId = undefined;
-        } else if (status === 'completed') {
-          agent.status = 'completed';
-        }
-
-        agent.lastActivity = new Date().toISOString();
-
-        if (oldStatus !== agent.status) {
-          handleStatusChangeNotificationCallback(agent, agent.status);
-
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('agent:status', {
-              agentId: agent.id,
-              status: agent.status,
-              waitingReason: waiting_reason
-            });
-          }
-        }
-
-        sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
-        return;
-      }
-
-      // POST /api/hooks/notification
-      if (pathname === '/api/hooks/notification' && req.method === 'POST') {
-        const { agent_id, session_id, type, title, message } = body as {
-          agent_id: string;
-          session_id: string;
-          type: string;
-          title: string;
-          message: string;
-        };
-
-        if (!agent_id || !type) {
-          sendJson({ error: 'agent_id and type are required' }, 400);
-          return;
-        }
-
-        let agent: AgentStatus | undefined = agents.get(agent_id);
-        if (!agent) {
-          for (const [, a] of agents) {
-            if (a.currentSessionId === session_id) {
-              agent = a;
-              break;
-            }
-          }
-        }
-
-        const agentName = agent?.name || 'Claude';
-
-        if (type === 'permission_prompt') {
-          if (appSettings.notifyOnWaiting) {
-            sendNotificationCallback(
-              `${agentName} needs permission`,
-              message || 'Claude needs your permission to proceed',
-              agent?.id
-            );
-          }
-        } else if (type === 'idle_prompt') {
-          if (appSettings.notifyOnWaiting) {
-            sendNotificationCallback(
-              `${agentName} is waiting`,
-              message || 'Claude is waiting for your input',
-              agent?.id
-            );
-          }
-        }
-
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('agent:notification', {
-            agentId: agent?.id,
-            type,
-            title,
-            message
-          });
-        }
-
-        sendJson({ success: true });
-        return;
-      }
-
-      // POST /api/scheduler/status — Agent self-reports task status
-      if (pathname === '/api/scheduler/status' && req.method === 'POST') {
-        const { task_id, status, summary } = body as {
-          task_id: string;
-          status: 'running' | 'success' | 'error' | 'partial';
-          summary?: string;
-        };
-
-        if (!task_id || !status) {
-          sendJson({ error: 'task_id and status are required' }, 400);
-          return;
-        }
-
-        const validStatuses = ['running', 'success', 'error', 'partial'];
-        if (!validStatuses.includes(status)) {
-          sendJson({ error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` }, 400);
-          return;
-        }
-
-        try {
-          const metadataPath = path.join(os.homedir(), '.dorothy', 'scheduler-metadata.json');
-          let metadata: Record<string, Record<string, unknown>> = {};
-          if (fs.existsSync(metadataPath)) {
-            metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf-8'));
-          }
-
-          if (!metadata[task_id]) {
-            metadata[task_id] = {};
-          }
-          metadata[task_id].lastRunStatus = status;
-          metadata[task_id].lastRun = new Date().toISOString();
-          if (summary) {
-            metadata[task_id].lastRunSummary = summary;
-          }
-
-          fs.writeFileSync(metadataPath, JSON.stringify(metadata, null, 2));
-
-          // Emit to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('scheduler:task-status', { taskId: task_id, status, summary });
-          }
-
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: `Failed to update status: ${err}` }, 500);
-        }
-        return;
-      }
-
-      // POST /api/kanban/generate - Generate task details from natural language prompt using Claude
-      if (pathname === '/api/kanban/generate' && req.method === 'POST') {
-        const { prompt, availableProjects } = body as {
-          prompt: string;
-          availableProjects: Array<{ path: string; name: string }>;
-        };
-
-        if (!prompt) {
-          sendJson({ error: 'prompt is required' }, 400);
-          return;
-        }
-
-        const task = await generateTaskFromPrompt(prompt, availableProjects);
-        sendJson({ success: true, task });
-        return;
-      }
-
-      // POST /api/kanban/complete - Mark a kanban task as complete (called by hooks)
-      // Can be called with task_id OR agent_id (will look up task by assigned agent)
-      if (pathname === '/api/kanban/complete' && req.method === 'POST') {
-        const { task_id, agent_id, session_id, summary } = body as {
-          task_id?: string;
-          agent_id?: string;
-          session_id?: string;
-          summary?: string;
-        };
-
-        try {
-          // Import kanban handlers functions
-          const { loadTasks, saveTasks, emitTaskEvent } = await import('../handlers/kanban-handlers');
-
-          const tasks = loadTasks();
-          let task;
-
-          // Find task by task_id or by assigned agent
-          if (task_id) {
-            task = tasks.find(t => t.id === task_id);
-          } else if (agent_id) {
-            task = tasks.find(t => t.assignedAgentId === agent_id && t.column === 'ongoing');
-          } else if (session_id) {
-            // Try to find agent by session ID, then find task
-            let agentIdFromSession: string | undefined;
-            for (const [id, agent] of agents) {
-              if (agent.currentSessionId === session_id) {
-                agentIdFromSession = id;
-                break;
-              }
-            }
-            if (agentIdFromSession) {
-              task = tasks.find(t => t.assignedAgentId === agentIdFromSession && t.column === 'ongoing');
-            }
-          }
-
-          if (!task) {
-            // No task found - this is OK, not all agents are kanban tasks
-            sendJson({ success: true, message: 'No kanban task found for this agent' });
-            return;
-          }
-
-          // Only complete if task is in ongoing state
-          if (task.column !== 'ongoing') {
-            sendJson({ success: true, message: 'Task already completed', currentColumn: task.column });
-            return;
-          }
-
-          // Update task
-          task.column = 'done';
-          task.progress = 100;
-          task.completedAt = new Date().toISOString();
-          task.updatedAt = new Date().toISOString();
-          if (summary) {
-            task.completionSummary = summary;
-          }
-
-          // Delete agent if it was created specifically for this task
-          if (task.agentCreatedForTask && task.assignedAgentId) {
-            const agentToDelete = agents.get(task.assignedAgentId);
-            if (agentToDelete) {
-              console.log(`[Kanban] Deleting agent ${task.assignedAgentId} created for task`);
-              agents.delete(task.assignedAgentId);
-            }
-          }
-
-          saveTasks(tasks);
-
-          // Emit event to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('kanban:task-updated', task);
-          }
-
-          console.log(`[Kanban] Task "${task.title}" marked as complete via hook`);
-          sendJson({ success: true, task });
-          return;
-        } catch (err) {
-          console.error('[Kanban] Failed to complete task:', err);
-          sendJson({ error: 'Failed to complete task' }, 500);
-          return;
-        }
-      }
-
-      // ============== Vault API Endpoints ==============
-
-      // GET /api/vault/documents
-      if (pathname === '/api/vault/documents' && req.method === 'GET') {
-        try {
-          const db = getVaultDb();
-          const folderId = url.searchParams.get('folder_id');
-          const tagsParam = url.searchParams.get('tags');
-
-          let query = 'SELECT * FROM documents';
-          const conditions: string[] = [];
-          const queryParams: unknown[] = [];
-
-          if (folderId) {
-            conditions.push('folder_id = ?');
-            queryParams.push(folderId);
-          }
-          if (tagsParam) {
-            const tags = tagsParam.split(',');
-            const tagConditions = tags.map(() => "tags LIKE ?");
-            conditions.push(`(${tagConditions.join(' OR ')})`);
-            tags.forEach(tag => queryParams.push(`%"${tag.trim()}"%`));
-          }
-
-          if (conditions.length > 0) {
-            query += ' WHERE ' + conditions.join(' AND ');
-          }
-          query += ' ORDER BY updated_at DESC';
-
-          const documents = db.prepare(query).all(...queryParams);
-          sendJson({ documents });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // POST /api/vault/documents
-      if (pathname === '/api/vault/documents' && req.method === 'POST') {
-        try {
-          const db = getVaultDb();
-          const { title, content, folder_id, author, agent_id, tags } = body as {
-            title: string; content: string; folder_id?: string;
-            author?: string; agent_id?: string; tags?: string[];
-          };
-
-          if (!title) {
-            sendJson({ error: 'title is required' }, 400);
-            return;
-          }
-
-          const id = uuidv4();
-          const now = new Date().toISOString();
-          const tagsJson = JSON.stringify(tags || []);
-
-          db.prepare(`
-            INSERT INTO documents (id, title, content, folder_id, author, agent_id, tags, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-          `).run(id, title, content || '', folder_id || null, author || 'api', agent_id || null, tagsJson, now, now);
-
-          const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(id);
-
-          // Emit event to frontend
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-created', document);
-          }
-
-          sendJson({ success: true, document });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // GET /api/vault/documents/:id
-      const vaultDocMatch = pathname.match(/^\/api\/vault\/documents\/([^/]+)$/);
-      if (vaultDocMatch && req.method === 'GET') {
-        try {
-          const db = getVaultDb();
-          const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(vaultDocMatch[1]);
-          if (!document) {
-            sendJson({ error: 'Document not found' }, 404);
-            return;
-          }
-          const attachments = db.prepare('SELECT * FROM attachments WHERE document_id = ? ORDER BY created_at DESC').all(vaultDocMatch[1]);
-          sendJson({ document, attachments });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // PUT /api/vault/documents/:id
-      if (vaultDocMatch && req.method === 'PUT') {
-        try {
-          const db = getVaultDb();
-          const docId = vaultDocMatch[1];
-          const existing = db.prepare('SELECT * FROM documents WHERE id = ?').get(docId);
-          if (!existing) {
-            sendJson({ error: 'Document not found' }, 404);
-            return;
-          }
-
-          const { title, content, tags, folder_id } = body as {
-            title?: string; content?: string; tags?: string[]; folder_id?: string | null;
-          };
-
-          const now = new Date().toISOString();
-          const updates: string[] = ['updated_at = ?'];
-          const values: unknown[] = [now];
-
-          if (title !== undefined) { updates.push('title = ?'); values.push(title); }
-          if (content !== undefined) { updates.push('content = ?'); values.push(content); }
-          if (tags !== undefined) { updates.push('tags = ?'); values.push(JSON.stringify(tags)); }
-          if (folder_id !== undefined) { updates.push('folder_id = ?'); values.push(folder_id); }
-
-          values.push(docId);
-          db.prepare(`UPDATE documents SET ${updates.join(', ')} WHERE id = ?`).run(...values);
-
-          const document = db.prepare('SELECT * FROM documents WHERE id = ?').get(docId);
-
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-updated', document);
-          }
-
-          sendJson({ success: true, document });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // DELETE /api/vault/documents/:id
-      if (vaultDocMatch && req.method === 'DELETE') {
-        try {
-          const db = getVaultDb();
-          const docId = vaultDocMatch[1];
-
-          // Delete attachment files
-          const attachments = db.prepare('SELECT filepath FROM attachments WHERE document_id = ?').all(docId) as { filepath: string }[];
-          for (const att of attachments) {
-            try { if (fs.existsSync(att.filepath)) fs.unlinkSync(att.filepath); } catch { /* ignore */ }
-          }
-
-          db.prepare('DELETE FROM documents WHERE id = ?').run(docId);
-
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            mainWindow.webContents.send('vault:document-deleted', { id: docId });
-          }
-
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // GET /api/vault/search
-      if (pathname === '/api/vault/search' && req.method === 'GET') {
-        try {
-          const db = getVaultDb();
-          const query = url.searchParams.get('q');
-          const limit = parseInt(url.searchParams.get('limit') || '20', 10);
-
-          if (!query) {
-            sendJson({ error: 'q parameter is required' }, 400);
-            return;
-          }
-
-          const results = db.prepare(`
-            SELECT d.*, snippet(documents_fts, 1, '<mark>', '</mark>', '...', 40) as snippet
-            FROM documents_fts fts
-            JOIN documents d ON d.rowid = fts.rowid
-            WHERE documents_fts MATCH ?
-            ORDER BY rank
-            LIMIT ?
-          `).all(query, limit);
-          sendJson({ results });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // GET /api/vault/folders
-      if (pathname === '/api/vault/folders' && req.method === 'GET') {
-        try {
-          const db = getVaultDb();
-          const folders = db.prepare('SELECT * FROM folders ORDER BY name').all();
-          sendJson({ folders });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // POST /api/vault/folders
-      if (pathname === '/api/vault/folders' && req.method === 'POST') {
-        try {
-          const db = getVaultDb();
-          const { name, parent_id } = body as { name: string; parent_id?: string };
-
-          if (!name) {
-            sendJson({ error: 'name is required' }, 400);
-            return;
-          }
-
-          const id = uuidv4();
-          const now = new Date().toISOString();
-          db.prepare('INSERT INTO folders (id, name, parent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)').run(id, name, parent_id || null, now, now);
-
-          const folder = db.prepare('SELECT * FROM folders WHERE id = ?').get(id);
-          sendJson({ success: true, folder });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // DELETE /api/vault/folders/:id
-      const vaultFolderMatch = pathname.match(/^\/api\/vault\/folders\/([^/]+)$/);
-      if (vaultFolderMatch && req.method === 'DELETE') {
-        try {
-          const db = getVaultDb();
-          const folderId = vaultFolderMatch[1];
-
-          // Move documents to root
-          db.prepare('UPDATE documents SET folder_id = NULL WHERE folder_id = ?').run(folderId);
-          db.prepare('DELETE FROM folders WHERE id = ?').run(folderId);
-
-          sendJson({ success: true });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // POST /api/vault/documents/:id/attach
-      const vaultAttachMatch = pathname.match(/^\/api\/vault\/documents\/([^/]+)\/attach$/);
-      if (vaultAttachMatch && req.method === 'POST') {
-        try {
-          const db = getVaultDb();
-          const docId = vaultAttachMatch[1];
-          const { file_path } = body as { file_path: string };
-
-          const doc = db.prepare('SELECT id FROM documents WHERE id = ?').get(docId);
-          if (!doc) {
-            sendJson({ error: 'Document not found' }, 404);
-            return;
-          }
-
-          if (!file_path || !fs.existsSync(file_path)) {
-            sendJson({ error: 'File not found' }, 400);
-            return;
-          }
-
-          const id = uuidv4();
-          const filename = path.basename(file_path);
-          const destPath = path.join(VAULT_DIR, 'attachments', `${id}-${filename}`);
-          fs.copyFileSync(file_path, destPath);
-
-          const stats = fs.statSync(destPath);
-          const ext = path.extname(filename).toLowerCase();
-          const mimeMap: Record<string, string> = {
-            '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
-            '.gif': 'image/gif', '.pdf': 'application/pdf', '.txt': 'text/plain',
-            '.md': 'text/markdown', '.json': 'application/json',
-          };
-          const mimetype = mimeMap[ext] || 'application/octet-stream';
-          const now = new Date().toISOString();
-
-          db.prepare('INSERT INTO attachments (id, document_id, filename, filepath, mimetype, size, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(id, docId, filename, destPath, mimetype, stats.size, now);
-
-          const attachment = db.prepare('SELECT * FROM attachments WHERE id = ?').get(id);
-          sendJson({ success: true, attachment });
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
-        return;
-      }
-
-      // GET /api/local-file?path=... — serve local files (for vault image previews)
-      if (pathname === '/api/local-file' && req.method === 'GET') {
-        const filePath = url.searchParams.get('path');
-        if (!filePath) {
-          sendJson({ error: 'File not found' }, 404);
-          return;
-        }
-        // Restrict to vault attachments directory to prevent arbitrary file read
-        const resolved = path.resolve(filePath);
-        const allowedDir = path.join(VAULT_DIR, 'attachments');
-        if (!resolved.startsWith(allowedDir + path.sep) && resolved !== allowedDir) {
-          sendJson({ error: 'Access denied: path outside allowed directory' }, 403);
-          return;
-        }
-        if (!fs.existsSync(resolved)) {
-          sendJson({ error: 'File not found' }, 404);
-          return;
-        }
-        try {
-          const ext = path.extname(resolved).toLowerCase();
-          const { MIME_TYPES } = require('../constants');
-          const mimeType = MIME_TYPES[ext] || 'application/octet-stream';
-          const stat = fs.statSync(resolved);
-          res.writeHead(200, {
-            'Content-Type': mimeType,
-            'Content-Length': stat.size,
-            'Cache-Control': 'public, max-age=3600',
-          });
-          fs.createReadStream(resolved).pipe(res);
-        } catch (err) {
-          sendJson({ error: String(err) }, 500);
-        }
+        await route.handler(routeReq, sendJson, ctx);
         return;
       }
 

--- a/electron/types/index.ts
+++ b/electron/types/index.ts
@@ -26,6 +26,7 @@ export interface AgentStatus {
   skipPermissions?: boolean;
   currentSessionId?: string;
   kanbanTaskId?: string;  // For kanban task completion tracking
+  lastCleanOutput?: string;  // Clean text output captured from transcript by hooks
   provider?: AgentProvider;   // 'claude' (default) or 'local' (Tasmania)
   localModel?: string;        // Tasmania model name when provider is 'local'
   obsidianVaultPaths?: string[]; // Obsidian vault paths to mount via --add-dir (read-only)

--- a/hooks/gemini/notification.sh
+++ b/hooks/gemini/notification.sh
@@ -12,7 +12,7 @@ API_URL="http://127.0.0.1:31415"
 AGENT_ID="${DOROTHY_AGENT_ID:-$SESSION_ID}"
 PROJECT_PATH="${DOROTHY_PROJECT_PATH:-$CWD}"
 
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi

--- a/hooks/gemini/on-stop.sh
+++ b/hooks/gemini/on-stop.sh
@@ -16,7 +16,7 @@ API_URL="http://127.0.0.1:31415"
 
 AGENT_ID="${DOROTHY_AGENT_ID:-$SESSION_ID}"
 
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi

--- a/hooks/gemini/session-end.sh
+++ b/hooks/gemini/session-end.sh
@@ -9,7 +9,7 @@ API_URL="http://127.0.0.1:31415"
 
 AGENT_ID="${DOROTHY_AGENT_ID:-$SESSION_ID}"
 
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi

--- a/hooks/gemini/session-start.sh
+++ b/hooks/gemini/session-start.sh
@@ -10,7 +10,7 @@ API_URL="http://127.0.0.1:31415"
 
 AGENT_ID="${DOROTHY_AGENT_ID:-$SESSION_ID}"
 
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi

--- a/hooks/notification.sh
+++ b/hooks/notification.sh
@@ -25,7 +25,7 @@ if [ -z "$NOTIFICATION_TYPE" ]; then
 fi
 
 # Check if API is available
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi

--- a/hooks/on-stop.sh
+++ b/hooks/on-stop.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Stop hook for dorothy
-# Sets agent status to "waiting" and captures summary
+# Sets agent status to "waiting" and captures clean output from transcript
 
 # Read JSON input from stdin
 INPUT=$(cat)
@@ -22,10 +22,9 @@ API_URL="http://127.0.0.1:31415"
 
 # Get agent ID from environment or use session ID
 AGENT_ID="${CLAUDE_AGENT_ID:-$SESSION_ID}"
-PROJECT_PATH="${CLAUDE_PROJECT_PATH:-$CWD}"
 
 # Check if API is available
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
 fi
@@ -36,27 +35,20 @@ curl -s -X POST "$API_URL/api/hooks/status" \
   -d "{\"agent_id\": \"$AGENT_ID\", \"session_id\": \"$SESSION_ID\", \"status\": \"waiting\"}" \
   > /dev/null 2>&1 &
 
-# Try to capture summary from transcript
+# Capture clean output from transcript for MCP tools
 if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
   # Extract the last assistant message from transcript (JSONL format)
   LAST_ASSISTANT_MSG=$(tail -100 "$TRANSCRIPT_PATH" 2>/dev/null | \
     grep '"type":"assistant"' | \
     tail -1 | \
     jq -r '.message.content[] | select(.type=="text") | .text // empty' 2>/dev/null | \
-    head -c 2000)
+    head -c 4000)
 
-  # If we got a message, check if it looks like a summary
   if [ -n "$LAST_ASSISTANT_MSG" ]; then
-    if echo "$LAST_ASSISTANT_MSG" | grep -qiE "(summary|completed|changes made|done|finished|created|updated|implemented|fixed|added|removed|refactored)"; then
-      # Clean up the message
-      CLEAN_MSG=$(echo "$LAST_ASSISTANT_MSG" | tr '\n' ' ' | sed 's/  */ /g' | head -c 1000)
-
-      # Store as a decision/summary
-      curl -s -X POST "$API_URL/api/memory/remember" \
-        -H "Content-Type: application/json" \
-        -d "{\"agent_id\": \"$AGENT_ID\", \"project_path\": \"$PROJECT_PATH\", \"content\": $(echo "$CLEAN_MSG" | jq -Rs .), \"type\": \"decision\"}" \
-        > /dev/null 2>&1 &
-    fi
+    curl -s -X POST "$API_URL/api/hooks/output" \
+      -H "Content-Type: application/json" \
+      -d "{\"agent_id\": \"$AGENT_ID\", \"session_id\": \"$SESSION_ID\", \"output\": $(echo "$LAST_ASSISTANT_MSG" | jq -Rs .)}" \
+      > /dev/null 2>&1 &
   fi
 fi
 

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # Session end hook for dorothy
-# Sets agent status to "idle" when session terminates
+# Sets agent status to "idle" when session terminates and captures final output
 
 # Read JSON input from stdin
 INPUT=$(cat)
 
 # Extract info
 SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
 REASON=$(echo "$INPUT" | jq -r '.reason // "other"')
 
@@ -17,9 +18,25 @@ API_URL="http://127.0.0.1:31415"
 AGENT_ID="${CLAUDE_AGENT_ID:-$SESSION_ID}"
 
 # Check if API is available
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   echo '{"continue":true,"suppressOutput":true}'
   exit 0
+fi
+
+# Capture final clean output from transcript before marking idle
+if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+  LAST_ASSISTANT_MSG=$(tail -100 "$TRANSCRIPT_PATH" 2>/dev/null | \
+    grep '"type":"assistant"' | \
+    tail -1 | \
+    jq -r '.message.content[] | select(.type=="text") | .text // empty' 2>/dev/null | \
+    head -c 4000)
+
+  if [ -n "$LAST_ASSISTANT_MSG" ]; then
+    curl -s -X POST "$API_URL/api/hooks/output" \
+      -H "Content-Type: application/json" \
+      -d "{\"agent_id\": \"$AGENT_ID\", \"session_id\": \"$SESSION_ID\", \"output\": $(echo "$LAST_ASSISTANT_MSG" | jq -Rs .)}" \
+      > /dev/null 2>&1 &
+  fi
 fi
 
 # Update agent status to "idle" (session ended)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -18,7 +18,7 @@ AGENT_ID="${CLAUDE_AGENT_ID:-$SESSION_ID}"
 PROJECT_PATH="${CLAUDE_PROJECT_PATH:-$CWD}"
 
 # Check if API is available
-if ! curl -s --connect-timeout 1 "$API_URL/api/memory/stats" > /dev/null 2>&1; then
+if ! curl -s --connect-timeout 1 "$API_URL/api/health" > /dev/null 2>&1; then
   # API not running, just continue
   echo '{"continue":true,"suppressOutput":true}'
   exit 0

--- a/mcp-kanban/src/index.ts
+++ b/mcp-kanban/src/index.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "crypto";
 // Data file path
 const DATA_DIR = path.join(os.homedir(), ".dorothy");
 const KANBAN_FILE = path.join(DATA_DIR, "kanban-tasks.json");
+const AGENTS_FILE = path.join(DATA_DIR, "agents.json");
 
 // Types
 type KanbanColumn = "backlog" | "planned" | "ongoing" | "done";
@@ -62,6 +63,28 @@ function saveTasks(tasks: KanbanTask[]): void {
   fs.writeFileSync(KANBAN_FILE, JSON.stringify(tasks, null, 2));
 }
 
+/** Resolve agent ID to human-readable name from agents.json */
+function getAgentName(agentId: string | null): string | null {
+  if (!agentId) return null;
+  try {
+    if (!fs.existsSync(AGENTS_FILE)) return null;
+    const data = JSON.parse(fs.readFileSync(AGENTS_FILE, "utf-8"));
+    // agents.json stores an array of agent objects
+    if (Array.isArray(data)) {
+      const agent = data.find((a: { id?: string }) => a.id === agentId);
+      return agent?.name || null;
+    }
+  } catch { /* ignore */ }
+  return null;
+}
+
+/** Format agent display: "Name (id-prefix)" or just "id-prefix" */
+function formatAgent(agentId: string | null): string {
+  if (!agentId) return "None";
+  const name = getAgentName(agentId);
+  return name ? `${name} (${agentId.slice(0, 8)})` : agentId.slice(0, 8);
+}
+
 // Create MCP server
 const server = new McpServer({
   name: "claude-mgr-kanban",
@@ -92,7 +115,7 @@ server.tool(
       }
 
       const summary = tasks.map(t =>
-        `- [${t.id.slice(0, 8)}] ${t.title} (${t.column}, ${t.progress}%${t.assignedAgentId ? `, agent: ${t.assignedAgentId.slice(0, 8)}` : ""})`
+        `- [${t.id.slice(0, 8)}] ${t.title} (${t.column}, ${t.progress}%${t.assignedAgentId ? `, agent: ${formatAgent(t.assignedAgentId)}` : ""})`
       ).join("\n");
 
       return {
@@ -147,7 +170,7 @@ Progress: ${task.progress}%
 Priority: ${task.priority}
 Description: ${task.description}
 Project: ${task.projectPath}
-Assigned Agent: ${task.assignedAgentId || "None"}
+Assigned Agent: ${formatAgent(task.assignedAgentId)}
 Labels: ${task.labels.join(", ") || "None"}
 Created: ${task.createdAt}
 Updated: ${task.updatedAt}${task.completionSummary ? `\nCompletion Summary: ${task.completionSummary}` : ""}`,
@@ -467,7 +490,7 @@ server.tool(
         content: [{
           type: "text",
           text: assignedId
-            ? `Task "${task.title}" assigned to agent ${assignedId.slice(0, 8)}`
+            ? `Task "${task.title}" assigned to ${formatAgent(assignedId)}`
             : `Task "${task.title}" unassigned`,
         }],
       };

--- a/mcp-orchestrator/src/tools/agents.ts
+++ b/mcp-orchestrator/src/tools/agents.ts
@@ -69,25 +69,40 @@ export function registerAgentTools(server: McpServer): void {
     }
   );
 
-  // Tool: Get agent output
+  // Tool: Get agent output (clean text from transcript, no ANSI)
   server.tool(
     "get_agent_output",
-    "Get the recent terminal output from an agent. Useful for checking what an agent has done or is currently doing.",
+    "Get the agent's last response as clean text (no terminal formatting). This is captured from the agent's transcript by hooks. Falls back to noting output is available in terminal view if no clean output is captured yet.",
     {
       id: z.string().describe("The agent ID"),
-      lines: z.number().optional().describe("Number of lines to retrieve (default: 100)"),
     },
-    async ({ id, lines = 100 }) => {
+    async ({ id }) => {
       try {
-        const data = (await apiRequest(`/api/agents/${id}/output?lines=${lines}`)) as {
-          output: string;
-          status: string;
+        const data = (await apiRequest(`/api/agents/${id}`)) as {
+          agent: {
+            status: string;
+            name?: string;
+            lastCleanOutput?: string;
+          };
         };
+        const agentName = data.agent.name || id;
+
+        if (data.agent.lastCleanOutput) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" (${data.agent.status}):\n\n${data.agent.lastCleanOutput}`,
+              },
+            ],
+          };
+        }
+
         return {
           content: [
             {
               type: "text",
-              text: `Agent status: ${data.status}\n\n--- Output ---\n${data.output}`,
+              text: `Agent "${agentName}" (${data.agent.status}): No clean output captured yet. The agent's terminal output is available in the Dorothy UI. Clean output is captured when the agent pauses or completes.`,
             },
           ],
         };
@@ -247,7 +262,7 @@ export function registerAgentTools(server: McpServer): void {
   // Tool: Send message to agent
   server.tool(
     "send_message",
-    "Send input/message to an agent. If the agent is idle, this will START the agent with the message as the prompt (with --dangerously-skip-permissions). If the agent is running/waiting, this sends the message as input.",
+    "Send input/message to an agent. If the agent is idle/completed/error, this will START the agent with the message as the prompt. If the agent is 'waiting', this sends the message as input. WARNING: Sending to a 'running' agent may interfere with its current work — prefer waiting until it reaches 'waiting' or 'completed' status.",
     {
       id: z.string().describe("The agent ID"),
       message: z.string().describe("The message to send to the agent"),
@@ -258,6 +273,7 @@ export function registerAgentTools(server: McpServer): void {
           agent: { status: string; name?: string };
         };
         const status = agentData.agent.status;
+        const agentName = agentData.agent.name || id;
 
         if (status === "idle" || status === "completed" || status === "error") {
           const startResult = (await apiRequest(`/api/agents/${id}/start`, "POST", {
@@ -268,7 +284,19 @@ export function registerAgentTools(server: McpServer): void {
             content: [
               {
                 type: "text",
-                text: `Agent ${agentData.agent.name || id} was ${status}, started it with prompt: "${message}". New status: ${startResult.agent.status}`,
+                text: `Agent "${agentName}" was ${status}, started it with prompt: "${message}". New status: ${startResult.agent.status}`,
+              },
+            ],
+          };
+        }
+
+        if (status === "running") {
+          await apiRequest(`/api/agents/${id}/message`, "POST", { message });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `⚠️ Agent "${agentName}" is currently running. Message sent but may interfere with current work. Consider using wait_for_agent first to wait until the agent is done.\nMessage sent: "${message}"`,
               },
             ],
           };
@@ -279,7 +307,7 @@ export function registerAgentTools(server: McpServer): void {
           content: [
             {
               type: "text",
-              text: `Sent message to agent ${agentData.agent.name || id}: "${message}"`,
+              text: `Sent message to agent "${agentName}" (${status}): "${message}"`,
             },
           ],
         };
@@ -329,100 +357,87 @@ export function registerAgentTools(server: McpServer): void {
     }
   );
 
-  // Tool: Wait for agent completion
+  // Tool: Wait for agent completion (long-poll, no polling loop)
   server.tool(
     "wait_for_agent",
-    "Poll an agent's status until it completes, errors, or needs input. Returns immediately if agent is idle (use start_agent first) or waiting for input (use send_message).",
+    "Wait for an agent to finish its current task. Uses long-polling for efficient waiting — returns as soon as the agent's status changes (no 5-second polling delay). Returns immediately if agent is already idle/waiting/completed/error.",
     {
       id: z.string().describe("The agent ID"),
       timeoutSeconds: z.number().optional().describe("Maximum time to wait in seconds (default: 300)"),
-      pollIntervalSeconds: z.number().optional().describe("How often to check status in seconds (default: 5)"),
     },
-    async ({ id, timeoutSeconds = 300, pollIntervalSeconds = 5 }) => {
-      const startTime = Date.now();
-      const timeoutMs = timeoutSeconds * 1000;
-      const pollIntervalMs = pollIntervalSeconds * 1000;
-
+    async ({ id, timeoutSeconds = 300 }) => {
       try {
-        const initialData = (await apiRequest(`/api/agents/${id}`)) as {
-          agent: { status: string; error?: string; currentTask?: string; name?: string };
+        // Single long-poll request to the wait endpoint
+        const data = (await apiRequest(
+          `/api/agents/${id}/wait?timeout=${timeoutSeconds}`
+        )) as {
+          status: string;
+          lastCleanOutput?: string;
+          error?: string;
+          timeout?: boolean;
         };
-        const agentName = initialData.agent.name || id;
 
-        if (initialData.agent.status === "idle") {
+        const agentData = (await apiRequest(`/api/agents/${id}`)) as {
+          agent: { name?: string };
+        };
+        const agentName = agentData.agent.name || id;
+
+        if (data.timeout) {
           return {
             content: [
               {
                 type: "text",
-                text: `Agent "${agentName}" is idle and not running. Use start_agent or send_message to give it a task first.`,
+                text: `Timeout after ${timeoutSeconds}s. Agent "${agentName}" is still '${data.status}'. Use get_agent_output to check progress.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (data.status === "completed" || data.status === "idle") {
+          const outputInfo = data.lastCleanOutput
+            ? `\n\nOutput:\n${data.lastCleanOutput}`
+            : "\n\nUse get_agent_output to read the result.";
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" finished (${data.status}).${outputInfo}`,
               },
             ],
           };
         }
 
-        while (Date.now() - startTime < timeoutMs) {
-          const data = (await apiRequest(`/api/agents/${id}`)) as {
-            agent: { status: string; error?: string; currentTask?: string; name?: string };
+        if (data.status === "error") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" encountered an error: ${data.error || "Unknown error"}`,
+              },
+            ],
+            isError: true,
           };
-          const status = data.agent.status;
-
-          if (status === "completed") {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Agent "${agentName}" completed successfully.`,
-                },
-              ],
-            };
-          }
-
-          if (status === "error") {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Agent "${agentName}" encountered an error: ${data.agent.error || "Unknown error"}`,
-                },
-              ],
-              isError: true,
-            };
-          }
-
-          if (status === "idle") {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Agent "${agentName}" finished and is now idle.`,
-                },
-              ],
-            };
-          }
-
-          if (status === "waiting") {
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Agent "${agentName}" is waiting for input. Use send_message to respond, or check get_agent_output to see what it's asking.`,
-                },
-              ],
-            };
-          }
-
-          await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
         }
 
-        const finalStatus = ((await apiRequest(`/api/agents/${id}`)) as { agent: { status: string } }).agent.status;
+        if (data.status === "waiting") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" is waiting for input. Use send_message to respond, or get_agent_output to see what it's asking.`,
+              },
+            ],
+          };
+        }
+
         return {
           content: [
             {
               type: "text",
-              text: `Timeout after ${timeoutSeconds}s. Agent "${agentName}" is still '${finalStatus}'. Check get_agent_output to see progress.`,
+              text: `Agent "${agentName}" status: ${data.status}`,
             },
           ],
-          isError: true,
         };
       } catch (error) {
         return {
@@ -430,6 +445,125 @@ export function registerAgentTools(server: McpServer): void {
             {
               type: "text",
               text: `Error waiting for agent: ${error instanceof Error ? error.message : String(error)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Tool: Delegate task (composite: start + wait + get output)
+  server.tool(
+    "delegate_task",
+    "Delegate a task to an agent and wait for the result. This is the primary tool for task delegation — it starts the agent, waits for completion using long-polling, and returns the clean text result. Much more efficient than calling start_agent + wait_for_agent + get_agent_output separately.",
+    {
+      id: z.string().describe("The agent ID to delegate to"),
+      prompt: z.string().describe("The task/instruction for the agent"),
+      model: z.string().optional().describe("Optional model to use (e.g., 'sonnet', 'opus')"),
+      timeoutSeconds: z.number().optional().describe("Maximum time to wait in seconds (default: 300)"),
+    },
+    async ({ id, prompt, model, timeoutSeconds = 300 }) => {
+      try {
+        // Get agent info
+        const agentData = (await apiRequest(`/api/agents/${id}`)) as {
+          agent: { status: string; name?: string };
+        };
+        const agentName = agentData.agent.name || id;
+        const status = agentData.agent.status;
+
+        // Start or send message
+        if (status === "running" || status === "waiting") {
+          await apiRequest(`/api/agents/${id}/message`, "POST", { message: prompt });
+        } else {
+          await apiRequest(`/api/agents/${id}/start`, "POST", {
+            prompt,
+            model,
+            skipPermissions: true,
+          });
+        }
+
+        // Wait for completion via long-poll
+        const waitData = (await apiRequest(
+          `/api/agents/${id}/wait?timeout=${timeoutSeconds}`
+        )) as {
+          status: string;
+          lastCleanOutput?: string;
+          error?: string;
+          timeout?: boolean;
+        };
+
+        if (waitData.timeout) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" is still running after ${timeoutSeconds}s. Use wait_for_agent to continue waiting, or get_agent_output to check progress.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (waitData.status === "error") {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" failed: ${waitData.error || "Unknown error"}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        if (waitData.status === "waiting") {
+          const outputInfo = waitData.lastCleanOutput
+            ? `\n\nAgent output:\n${waitData.lastCleanOutput}`
+            : "";
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" is waiting for input.${outputInfo}\n\nUse send_message to respond.`,
+              },
+            ],
+          };
+        }
+
+        // Completed or idle — get the output
+        // Re-fetch to get latest lastCleanOutput (hooks may have updated it)
+        const finalAgent = (await apiRequest(`/api/agents/${id}`)) as {
+          agent: { lastCleanOutput?: string; status: string };
+        };
+
+        const output = finalAgent.agent.lastCleanOutput || waitData.lastCleanOutput;
+
+        if (output) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Agent "${agentName}" completed.\n\n${output}`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Agent "${agentName}" completed (${waitData.status}). No clean output captured — check the agent's terminal in Dorothy UI for details.`,
+            },
+          ],
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error delegating task: ${error instanceof Error ? error.message : String(error)}`,
             },
           ],
           isError: true,

--- a/mcp-orchestrator/src/utils/api.ts
+++ b/mcp-orchestrator/src/utils/api.ts
@@ -29,20 +29,33 @@ export async function apiRequest(
   if (token) {
     headers["Authorization"] = `Bearer ${token}`;
   }
+
+  // Long-poll wait endpoints need a longer timeout
+  const isLongPoll = endpoint.includes("/wait");
+  const timeoutMs = isLongPoll ? 600_000 : 30_000; // 10 min for long-poll, 30s default
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
   const options: RequestInit = {
     method,
     headers,
+    signal: controller.signal,
   };
   if (body) {
     options.body = JSON.stringify(body);
   }
 
-  const response = await fetch(url, options);
-  const data = await response.json();
+  try {
+    const response = await fetch(url, options);
+    const data = await response.json();
 
-  if (!response.ok) {
-    throw new Error((data as { error?: string }).error || `API error: ${response.status}`);
+    if (!response.ok) {
+      throw new Error((data as { error?: string }).error || `API error: ${response.status}`);
+    }
+
+    return data;
+  } finally {
+    clearTimeout(timer);
   }
-
-  return data;
 }

--- a/src/app/skills/page.tsx
+++ b/src/app/skills/page.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import { useClaude } from '@/hooks/useClaude';
 import { useElectronSkills } from '@/hooks/useElectron';
-import { SKILLS_DATABASE, type Skill } from '@/lib/skills-database';
+import { SKILLS_DATABASE, fetchSkillsFromMarketplace, type Skill } from '@/lib/skills-database';
 import TerminalDialog from '@/components/TerminalDialog';
 import ProviderBadge from '@/components/ProviderBadge';
 
@@ -54,12 +54,8 @@ export default function SkillsPage() {
   const [loadingSkills, setLoadingSkills] = useState(true);
 
   useEffect(() => {
-    fetch('/api/skills/marketplace')
-      .then(res => res.ok ? res.json() : null)
-      .then(data => {
-        if (data?.skills) setLiveSkills(data.skills);
-      })
-      .catch(() => { }) // fallback to hardcoded
+    fetchSkillsFromMarketplace()
+      .then(skills => { if (skills) setLiveSkills(skills); })
       .finally(() => setLoadingSkills(false));
   }, []);
 

--- a/src/components/ClientLayout.tsx
+++ b/src/components/ClientLayout.tsx
@@ -19,6 +19,22 @@ function useIsMobile() {
   return isMobile;
 }
 
+/** Strip HTML tags and collapse whitespace so release notes render as plain text. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:p|li|h[1-6]|div|tr)>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '- ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 interface UpdateInfo {
   currentVersion: string;
   latestVersion: string;
@@ -250,7 +266,7 @@ export default function ClientLayout({ children }: { children: React.ReactNode }
                 <div className="mb-4">
                   <p className="text-xs font-medium text-muted-foreground mb-1">Release notes:</p>
                   <p className="text-sm text-foreground/80 whitespace-pre-wrap line-clamp-6">
-                    {updateInfo.releaseNotes.slice(0, 400)}
+                    {stripHtml(updateInfo.releaseNotes).slice(0, 400)}
                     {updateInfo.releaseNotes.length > 400 ? '...' : ''}
                   </p>
                 </div>

--- a/src/components/Settings/GeneralSection.tsx
+++ b/src/components/Settings/GeneralSection.tsx
@@ -3,6 +3,22 @@ import { Settings, RefreshCw, Download, ExternalLink, CheckCircle, AlertCircle, 
 import { Toggle } from './Toggle';
 import type { ClaudeInfo, AppSettings } from './types';
 
+/** Strip HTML tags and collapse whitespace so release notes render as plain text. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(?:p|li|h[1-6]|div|tr)>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '- ')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 interface UpdateInfo {
   currentVersion: string;
   latestVersion: string;
@@ -213,7 +229,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
                 <div className="mt-3 pt-3 border-t border-blue-500/20">
                   <p className="text-xs text-muted-foreground mb-1">Release notes:</p>
                   <p className="text-xs text-foreground/80 whitespace-pre-wrap line-clamp-4">
-                    {updateInfo.releaseNotes.slice(0, 300)}
+                    {stripHtml(updateInfo.releaseNotes).slice(0, 300)}
                     {updateInfo.releaseNotes.length > 300 ? '...' : ''}
                   </p>
                 </div>

--- a/src/hooks/useAgentTerminal.ts
+++ b/src/hooks/useAgentTerminal.ts
@@ -196,6 +196,8 @@ export function useAgentTerminal({ selectedAgentId, terminalRef, provider, termi
                 term.write(line);
               });
             }
+            // Ensure terminal scrolls to bottom after replaying output
+            term.scrollToBottom();
           } else {
             term.writeln('\x1b[90m(No previous output)\x1b[0m');
           }

--- a/src/lib/skills-database.ts
+++ b/src/lib/skills-database.ts
@@ -112,6 +112,34 @@ export const SKILLS_DATABASE: Skill[] = [
   { rank: 100, name: 'vue', repo: 'onmax/nuxt-skills', installs: '478', category: 'Frontend' },
 ];
 
+/**
+ * Fetch live skills from skills.sh.
+ * In Electron: uses IPC to fetch from the main process (avoids CORS).
+ * In dev/web: uses the Next.js API route.
+ * Returns null on failure so callers can fall back to SKILLS_DATABASE.
+ */
+export async function fetchSkillsFromMarketplace(): Promise<Skill[] | null> {
+  // Electron path: fetch via IPC (main process, no CORS)
+  if (typeof window !== 'undefined' && window.electronAPI?.skill?.fetchMarketplace) {
+    try {
+      const result = await window.electronAPI.skill.fetchMarketplace();
+      return result.skills;
+    } catch {
+      return null;
+    }
+  }
+
+  // Dev/web path: use the Next.js API route
+  try {
+    const res = await fetch('/api/skills/marketplace');
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data?.skills || null;
+  } catch {
+    return null;
+  }
+}
+
 // Get unique categories
 export const SKILL_CATEGORIES = [...new Set(SKILLS_DATABASE.map(s => s.category).filter((c): c is string => !!c))].sort();
 

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -207,6 +207,7 @@ export interface ElectronAPI {
     listInstalled: () => Promise<string[]>;
     listInstalledAll: () => Promise<Record<string, string[]>>;
     linkToProvider: (params: { skillName: string; providerId: string }) => Promise<{ success: boolean; error?: string }>;
+    fetchMarketplace: () => Promise<{ skills: Array<{ rank: number; name: string; repo: string; installs: string; installsNum: number }> | null }>;
     onPtyData: (callback: (event: { id: string; data: string }) => void) => () => void;
     onPtyExit: (callback: (event: { id: string; exitCode: number }) => void) => () => void;
     onInstallOutput: (callback: (event: SkillInstallOutputEvent) => void) => () => void;


### PR DESCRIPTION
…, improve UX

- Refactor api-server.ts (1323 lines) into 11 domain-focused route files under electron/services/api-routes/ with a thin dispatch shell (~160 lines). Zero import path changes — all exports preserved. 63 new route tests added.

- Fix skills marketplace showing 100 hardcoded skills in production instead of 300 live skills from skills.sh. Root cause: static export strips Next.js API routes. Fix: fetch via IPC from Electron main process (no CORS), fall back to API route in dev.

- Fix update dialog rendering raw HTML in release notes by stripping tags to plain text in both ClientLayout and GeneralSection.

- Enhance super agent Telegram feedback: rewrite prompt instructions to require send_telegram before every blocking tool call so users get real-time progress updates instead of silence.