### PR TITLE
feat: support self-hosted JIRA instances and custom domains

### DIFF
--- a/__tests__/electron/handlers/scheduler-handlers.test.ts
+++ b/__tests__/electron/handlers/scheduler-handlers.test.ts
@@ -117,6 +117,8 @@ describe('scheduler-handlers', () => {
         verboseModeEnabled: false,
         autoCheckUpdates: true,
         defaultProvider: 'claude' as const,
+        opencodeEnabled: false,
+        opencodeDefaultModel: '',
         cliPaths: { claude: '', codex: '', gemini: '', opencode: '', gws: '', gcloud: '', gh: '', node: '', additionalPaths: [] },
       }),
     });

--- a/__tests__/electron/utils/normalize-jira-host.test.ts
+++ b/__tests__/electron/utils/normalize-jira-host.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * normalizeJiraHost — replicated from electron/handlers/ipc-handlers.ts
+ * and mcp-orchestrator/src/tools/automations.ts (identical logic in both).
+ */
+function normalizeJiraHost(domain: string): string {
+  let host = domain.trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  if (!host.includes('.')) {
+    host = `${host}.atlassian.net`;
+  }
+  return host;
+}
+
+describe('normalizeJiraHost', () => {
+  // ── Legacy subdomain-only values (backward compat) ──────────────────────
+
+  it('appends .atlassian.net to bare subdomain', () => {
+    expect(normalizeJiraHost('mycompany')).toBe('mycompany.atlassian.net');
+  });
+
+  it('handles single-word subdomain with extra whitespace', () => {
+    expect(normalizeJiraHost('  mycompany  ')).toBe('mycompany.atlassian.net');
+  });
+
+  // ── Full Atlassian Cloud hostnames ──────────────────────────────────────
+
+  it('passes through full atlassian.net hostname', () => {
+    expect(normalizeJiraHost('mycompany.atlassian.net')).toBe('mycompany.atlassian.net');
+  });
+
+  it('does not double-append .atlassian.net', () => {
+    expect(normalizeJiraHost('mycompany.atlassian.net')).toBe('mycompany.atlassian.net');
+  });
+
+  // ── Self-hosted / custom domains ───────────────────────────────────────
+
+  it('passes through self-hosted domain', () => {
+    expect(normalizeJiraHost('jira.example.com')).toBe('jira.example.com');
+  });
+
+  it('passes through self-hosted domain with subdomain', () => {
+    expect(normalizeJiraHost('issues.corp.example.com')).toBe('issues.corp.example.com');
+  });
+
+  it('passes through IP-based host with port-like subdomain', () => {
+    // e.g. jira.10.0.0.1 — has dots, should not append
+    expect(normalizeJiraHost('jira.10.0.0.1')).toBe('jira.10.0.0.1');
+  });
+
+  // ── https:// prefix stripping ──────────────────────────────────────────
+
+  it('strips https:// prefix from full hostname', () => {
+    expect(normalizeJiraHost('https://mycompany.atlassian.net')).toBe('mycompany.atlassian.net');
+  });
+
+  it('strips http:// prefix from full hostname', () => {
+    expect(normalizeJiraHost('http://jira.example.com')).toBe('jira.example.com');
+  });
+
+  it('strips https:// prefix from bare subdomain', () => {
+    expect(normalizeJiraHost('https://mycompany')).toBe('mycompany.atlassian.net');
+  });
+
+  // ── Trailing slash stripping ───────────────────────────────────────────
+
+  it('strips trailing slash from hostname', () => {
+    expect(normalizeJiraHost('mycompany.atlassian.net/')).toBe('mycompany.atlassian.net');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeJiraHost('jira.example.com///')).toBe('jira.example.com');
+  });
+
+  it('strips both https:// prefix and trailing slash', () => {
+    expect(normalizeJiraHost('https://mycompany.atlassian.net/')).toBe('mycompany.atlassian.net');
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────────────
+
+  it('handles empty string (returns .atlassian.net — caller validates)', () => {
+    // Empty after trim has no dot → appends suffix
+    expect(normalizeJiraHost('')).toBe('.atlassian.net');
+  });
+
+  it('handles whitespace-only string', () => {
+    expect(normalizeJiraHost('   ')).toBe('.atlassian.net');
+  });
+
+  it('handles hostname with port in subdomain style', () => {
+    // "jira.example.com:8080" — has a dot, passes through
+    expect(normalizeJiraHost('jira.example.com:8080')).toBe('jira.example.com:8080');
+  });
+
+  it('handles mixed case', () => {
+    expect(normalizeJiraHost('MyCompany.Atlassian.Net')).toBe('MyCompany.Atlassian.Net');
+  });
+});

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -22,6 +22,20 @@ import { writeProgrammaticInput } from '../core/pty-manager';
 import { extractStatusLine } from '../utils/ansi';
 import { scheduleTick } from '../utils/agents-tick';
 
+/**
+ * Normalize a JIRA domain value to a full hostname.
+ * Handles both legacy subdomain-only values (e.g. "mycompany") and
+ * full hostnames (e.g. "mycompany.atlassian.net", "issues.example.com").
+ */
+function normalizeJiraHost(domain: string): string {
+  let host = domain.trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  // Legacy: bare subdomain without dots → append .atlassian.net
+  if (!host.includes('.')) {
+    host = `${host}.atlassian.net`;
+  }
+  return host;
+}
+
 // Dependencies interface for dependency injection
 export interface IpcHandlerDependencies {
   // State
@@ -1521,7 +1535,8 @@ function registerAppSettingsHandlers(deps: IpcHandlerDependencies): void {
 
     try {
       const auth = Buffer.from(`${appSettings.jiraEmail}:${appSettings.jiraApiToken}`).toString('base64');
-      const res = await fetch(`https://${appSettings.jiraDomain}.atlassian.net/rest/api/3/myself`, {
+      const jiraHost = normalizeJiraHost(appSettings.jiraDomain);
+      const res = await fetch(`https://${jiraHost}/rest/api/3/myself`, {
         headers: {
           'Authorization': `Basic ${auth}`,
           'Content-Type': 'application/json',

--- a/mcp-orchestrator/src/tools/automations.ts
+++ b/mcp-orchestrator/src/tools/automations.ts
@@ -42,6 +42,19 @@ import { apiRequest } from "../utils/api.js";
 const execAsyncRaw = promisify(exec);
 
 /**
+ * Normalize a JIRA domain value to a full hostname.
+ * Handles both legacy subdomain-only values (e.g. "mycompany") and
+ * full hostnames (e.g. "mycompany.atlassian.net", "issues.example.com").
+ */
+function normalizeJiraHost(domain: string): string {
+  let host = domain.trim().replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  if (!host.includes('.')) {
+    host = `${host}.atlassian.net`;
+  }
+  return host;
+}
+
+/**
  * Validate that a webhook URL is safe (not targeting internal/private networks).
  * Requires HTTPS and rejects localhost, private IPs, and link-local addresses.
  */
@@ -396,7 +409,8 @@ async function pollJira(config: JiraSourceConfig, automation: Automation): Promi
       }
     }
 
-    const searchUrl = `https://${domain}.atlassian.net/rest/api/3/search/jql`;
+    const jiraHost = normalizeJiraHost(domain);
+    const searchUrl = `https://${jiraHost}/rest/api/3/search/jql`;
     const res = await fetch(searchUrl, {
       method: "POST",
       headers,
@@ -424,7 +438,7 @@ async function pollJira(config: JiraSourceConfig, automation: Automation): Promi
         id: createItemId("jira", domain, "issue", issue.key),
         type: fields.issuetype?.name || "Issue",
         title: fields.summary || issue.key,
-        url: `https://${domain}.atlassian.net/browse/${issue.key}`,
+        url: `https://${jiraHost}/browse/${issue.key}`,
         author: fields.reporter?.displayName || "Unknown",
         body: descriptionText,
         labels: fields.labels || [],
@@ -511,7 +525,7 @@ async function sendOutput(output: OutputConfig, message: string, variables: Reco
         const jiraCreds = loadJiraCredentials({ domain: jiraDomain, projectKeys: [] } as JiraSourceConfig);
         if (jiraCreds) {
           const jiraHeaders = jiraAuthHeaders(jiraCreds.email, jiraCreds.apiToken);
-          await fetch(`https://${jiraCreds.domain}.atlassian.net/rest/api/3/issue/${issueKey}/comment`, {
+          await fetch(`https://${normalizeJiraHost(jiraCreds.domain)}/rest/api/3/issue/${issueKey}/comment`, {
             method: "POST",
             headers: jiraHeaders,
             body: JSON.stringify({
@@ -537,7 +551,8 @@ async function sendOutput(output: OutputConfig, message: string, variables: Reco
         if (jiraCreds) {
           const jiraHeaders = jiraAuthHeaders(jiraCreds.email, jiraCreds.apiToken);
           // Get available transitions
-          const transRes = await fetch(`https://${jiraCreds.domain}.atlassian.net/rest/api/3/issue/${transIssueKey}/transitions`, {
+          const jiraTransHost = normalizeJiraHost(jiraCreds.domain);
+          const transRes = await fetch(`https://${jiraTransHost}/rest/api/3/issue/${transIssueKey}/transitions`, {
             headers: jiraHeaders,
           });
           if (transRes.ok) {
@@ -546,7 +561,7 @@ async function sendOutput(output: OutputConfig, message: string, variables: Reco
               t.name.toLowerCase() === targetTransition.toLowerCase()
             );
             if (transition) {
-              await fetch(`https://${jiraCreds.domain}.atlassian.net/rest/api/3/issue/${transIssueKey}/transitions`, {
+              await fetch(`https://${jiraTransHost}/rest/api/3/issue/${transIssueKey}/transitions`, {
                 method: "POST",
                 headers: jiraHeaders,
                 body: JSON.stringify({ transition: { id: transition.id } }),
@@ -1337,7 +1352,8 @@ ${run.agentOutput ? `Output: ${run.agentOutput.slice(0, 200)}...` : ""}`,
 
         // Transition if requested
         if (transitionName) {
-          const transRes = await fetch(`https://${creds.domain}.atlassian.net/rest/api/3/issue/${issueKey}/transitions`, {
+          const updateHost = normalizeJiraHost(creds.domain);
+          const transRes = await fetch(`https://${updateHost}/rest/api/3/issue/${issueKey}/transitions`, {
             headers,
           });
           if (transRes.ok) {
@@ -1346,7 +1362,7 @@ ${run.agentOutput ? `Output: ${run.agentOutput.slice(0, 200)}...` : ""}`,
               t.name.toLowerCase() === transitionName.toLowerCase()
             );
             if (transition) {
-              const doTransRes = await fetch(`https://${creds.domain}.atlassian.net/rest/api/3/issue/${issueKey}/transitions`, {
+              const doTransRes = await fetch(`https://${updateHost}/rest/api/3/issue/${issueKey}/transitions`, {
                 method: "POST",
                 headers,
                 body: JSON.stringify({ transition: { id: transition.id } }),
@@ -1368,7 +1384,7 @@ ${run.agentOutput ? `Output: ${run.agentOutput.slice(0, 200)}...` : ""}`,
 
         // Add comment if requested
         if (comment) {
-          const commentRes = await fetch(`https://${creds.domain}.atlassian.net/rest/api/3/issue/${issueKey}/comment`, {
+          const commentRes = await fetch(`https://${updateHost}/rest/api/3/issue/${issueKey}/comment`, {
             method: "POST",
             headers,
             body: JSON.stringify({

--- a/src/components/Settings/JiraSection.tsx
+++ b/src/components/Settings/JiraSection.tsx
@@ -49,7 +49,7 @@ export const JiraSection = ({ appSettings, onSaveAppSettings, onUpdateLocalSetti
     <div className="space-y-6">
       <div>
         <h2 className="text-lg font-semibold mb-1">JIRA Integration</h2>
-        <p className="text-sm text-muted-foreground">Connect to JIRA Cloud to poll issues and update status</p>
+        <p className="text-sm text-muted-foreground">Connect to JIRA to poll issues and update status</p>
       </div>
 
       <div className="border border-border bg-card p-6">
@@ -76,22 +76,21 @@ export const JiraSection = ({ appSettings, onSaveAppSettings, onUpdateLocalSetti
           {/* Domain */}
           <div>
             <label className="text-sm font-medium block mb-2">JIRA Domain</label>
-            <div className="flex items-center gap-2">
-              <span className="text-sm text-muted-foreground">https://</span>
-              <input
-                type="text"
-                value={appSettings.jiraDomain}
-                onChange={(e) => onUpdateLocalSettings({ jiraDomain: e.target.value })}
-                onBlur={() => {
-                  if (appSettings.jiraDomain) {
-                    onSaveAppSettings({ jiraDomain: appSettings.jiraDomain });
-                  }
-                }}
-                placeholder="mycompany"
-                className="flex-1 px-3 py-2 bg-secondary border border-border text-sm font-mono focus:border-foreground focus:outline-none"
-              />
-              <span className="text-sm text-muted-foreground">.atlassian.net</span>
-            </div>
+            <input
+              type="text"
+              value={appSettings.jiraDomain}
+              onChange={(e) => onUpdateLocalSettings({ jiraDomain: e.target.value })}
+              onBlur={() => {
+                if (appSettings.jiraDomain) {
+                  onSaveAppSettings({ jiraDomain: appSettings.jiraDomain });
+                }
+              }}
+              placeholder="mycompany.atlassian.net or issues.example.com"
+              className="w-full px-3 py-2 bg-secondary border border-border text-sm font-mono focus:border-foreground focus:outline-none"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Full hostname — e.g. mycompany.atlassian.net or your self-hosted domain
+            </p>
           </div>
 
           {/* Email */}
@@ -184,7 +183,7 @@ export const JiraSection = ({ appSettings, onSaveAppSettings, onUpdateLocalSetti
         <ol className="text-sm text-muted-foreground space-y-2 list-decimal list-inside">
           <li>Go to your Atlassian account security settings</li>
           <li>Create an API token at <code className="bg-secondary px-1">id.atlassian.com/manage-profile/security/api-tokens</code></li>
-          <li>Enter your JIRA domain (the subdomain before .atlassian.net)</li>
+          <li>Enter your JIRA hostname (e.g. mycompany.atlassian.net or your self-hosted domain)</li>
           <li>Enter the email associated with your Atlassian account</li>
           <li>Paste your API token and click &quot;Test Connection&quot;</li>
           <li>Create an automation with JIRA as the source</li>


### PR DESCRIPTION
Replace hardcoded .atlassian.net suffix with normalizeJiraHost() that accepts full hostnames (e.g. issues.example.com) while remaining backward-compatible with existing bare subdomain values. Update UI to accept full hostnames. Fix AppSettings type error in scheduler tests.