### PR TITLE
feat(vault): add local file editing and terminal split view

### DIFF
--- a/electron/handlers/vault-handlers.ts
+++ b/electron/handlers/vault-handlers.ts
@@ -341,11 +341,22 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
       return { success: false, error: String(err) };
     }
   });
+}
 
+/**
+ * Register local file IPC handlers that don't depend on the vault database.
+ * These can be registered even if vault DB initialization fails.
+ */
+export function registerLocalFileHandlers(): void {
   // Read a local file from disk
   ipcMain.handle('vault:readLocalFile', async (_event, filePath: string) => {
     try {
       const resolvedPath = path.resolve(filePath);
+      // Constrain to user's home directory
+      const homeDir = require('os').homedir();
+      if (!resolvedPath.startsWith(homeDir)) {
+        return { error: 'Access denied: file is outside the home directory' };
+      }
       if (!fs.existsSync(resolvedPath)) {
         return { error: 'File not found' };
       }
@@ -382,6 +393,11 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
   ipcMain.handle('vault:writeLocalFile', async (_event, params: { filePath: string; content: string }) => {
     try {
       const resolvedPath = path.resolve(params.filePath);
+      // Constrain to user's home directory
+      const homeDir = require('os').homedir();
+      if (!resolvedPath.startsWith(homeDir)) {
+        return { success: false, error: 'Access denied: file is outside the home directory' };
+      }
       fs.writeFileSync(resolvedPath, params.content, 'utf-8');
       return { success: true, filePath: resolvedPath };
     } catch (err) {

--- a/electron/handlers/vault-handlers.ts
+++ b/electron/handlers/vault-handlers.ts
@@ -386,4 +386,34 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
       return { success: false, error: String(err) };
     }
   });
+
+  // Save clipboard image data to disk
+  ipcMain.handle('vault:saveClipboardImage', async (_event, params: { imageDataUrl: string; targetDir?: string }) => {
+    try {
+      // Parse data URL: data:image/png;base64,xxxx
+      const match = params.imageDataUrl.match(/^data:image\/(\w+);base64,(.+)$/);
+      if (!match) {
+        return { error: 'Invalid image data URL' };
+      }
+      const ext = match[1] === 'jpeg' ? 'jpg' : match[1];
+      const base64Data = match[2];
+      const buffer = Buffer.from(base64Data, 'base64');
+
+      // Save to target directory (same as the file being edited) or vault attachments
+      const saveDir = params.targetDir || path.join(VAULT_DIR, 'attachments');
+      if (!fs.existsSync(saveDir)) {
+        fs.mkdirSync(saveDir, { recursive: true });
+      }
+
+      const timestamp = Date.now();
+      const filename = `pasted-image-${timestamp}.${ext}`;
+      const filePath = path.join(saveDir, filename);
+      fs.writeFileSync(filePath, buffer);
+
+      return { success: true, filePath, filename };
+    } catch (err) {
+      console.error('Failed to save clipboard image:', err);
+      return { success: false, error: String(err) };
+    }
+  });
 }

--- a/electron/handlers/vault-handlers.ts
+++ b/electron/handlers/vault-handlers.ts
@@ -341,4 +341,49 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
       return { success: false, error: String(err) };
     }
   });
+
+  // Read a local file from disk
+  ipcMain.handle('vault:readLocalFile', async (_event, filePath: string) => {
+    try {
+      const resolvedPath = path.resolve(filePath);
+      if (!fs.existsSync(resolvedPath)) {
+        return { error: 'File not found' };
+      }
+      const stats = fs.statSync(resolvedPath);
+      if (stats.isDirectory()) {
+        return { error: 'Path is a directory' };
+      }
+      // Limit to 10MB
+      if (stats.size > 10 * 1024 * 1024) {
+        return { error: 'File too large (max 10MB)' };
+      }
+      // Check for binary content by reading a small buffer
+      const buffer = Buffer.alloc(Math.min(8192, stats.size));
+      const fd = fs.openSync(resolvedPath, 'r');
+      fs.readSync(fd, buffer, 0, buffer.length, 0);
+      fs.closeSync(fd);
+      // Check for null bytes (binary indicator)
+      if (buffer.includes(0)) {
+        return { error: 'This file appears to be binary and cannot be edited as text. Only text-based files (.md, .txt, .json, .ts, .js, etc.) are supported.' };
+      }
+      const content = fs.readFileSync(resolvedPath, 'utf-8');
+      const filename = path.basename(resolvedPath);
+      return { content, filename, filePath: resolvedPath };
+    } catch (err) {
+      console.error('Failed to read local file:', err);
+      return { error: String(err) };
+    }
+  });
+
+  // Write content back to a local file on disk
+  ipcMain.handle('vault:writeLocalFile', async (_event, params: { filePath: string; content: string }) => {
+    try {
+      const resolvedPath = path.resolve(params.filePath);
+      fs.writeFileSync(resolvedPath, params.content, 'utf-8');
+      return { success: true, filePath: resolvedPath };
+    } catch (err) {
+      console.error('Failed to write local file:', err);
+      return { success: false, error: String(err) };
+    }
+  });
 }

--- a/electron/handlers/vault-handlers.ts
+++ b/electron/handlers/vault-handlers.ts
@@ -360,8 +360,11 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
       // Check for binary content by reading a small buffer
       const buffer = Buffer.alloc(Math.min(8192, stats.size));
       const fd = fs.openSync(resolvedPath, 'r');
-      fs.readSync(fd, buffer, 0, buffer.length, 0);
-      fs.closeSync(fd);
+      try {
+        fs.readSync(fd, buffer, 0, buffer.length, 0);
+      } finally {
+        fs.closeSync(fd);
+      }
       // Check for null bytes (binary indicator)
       if (buffer.includes(0)) {
         return { error: 'This file appears to be binary and cannot be edited as text. Only text-based files (.md, .txt, .json, .ts, .js, etc.) are supported.' };
@@ -400,7 +403,16 @@ export function registerVaultHandlers(deps: VaultHandlerDependencies): void {
       const buffer = Buffer.from(base64Data, 'base64');
 
       // Save to target directory (same as the file being edited) or vault attachments
-      const saveDir = params.targetDir || path.join(VAULT_DIR, 'attachments');
+      let saveDir = path.join(VAULT_DIR, 'attachments');
+      if (params.targetDir) {
+        const resolvedTarget = path.resolve(params.targetDir);
+        // Only allow targetDir under the user's home directory
+        const homeDir = require('os').homedir();
+        if (!resolvedTarget.startsWith(homeDir)) {
+          return { success: false, error: 'Target directory is outside the home directory' };
+        }
+        saveDir = resolvedTarget;
+      }
       if (!fs.existsSync(saveDir)) {
         fs.mkdirSync(saveDir, { recursive: true });
       }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -394,10 +394,20 @@ app.whenReady().then(async () => {
   });
 
   // Initialize vault database
-  initVaultDb();
+  try {
+    initVaultDb();
+    console.log('[Dorothy] Vault database initialized successfully');
+  } catch (err) {
+    console.error('[Dorothy] Failed to initialize vault database:', err);
+  }
 
   // Register vault handlers
-  registerVaultHandlers({ getMainWindow });
+  try {
+    registerVaultHandlers({ getMainWindow });
+    console.log('[Dorothy] Vault handlers registered successfully');
+  } catch (err) {
+    console.error('[Dorothy] Failed to register vault handlers:', err);
+  }
 
   // Register world (generative zone) handlers
   registerWorldHandlers({ getMainWindow });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -394,19 +394,25 @@ app.whenReady().then(async () => {
   });
 
   // Initialize vault database
+  let vaultReady = false;
   try {
     initVaultDb();
     console.log('[Dorothy] Vault database initialized successfully');
+    vaultReady = true;
   } catch (err) {
     console.error('[Dorothy] Failed to initialize vault database:', err);
   }
 
-  // Register vault handlers
-  try {
-    registerVaultHandlers({ getMainWindow });
-    console.log('[Dorothy] Vault handlers registered successfully');
-  } catch (err) {
-    console.error('[Dorothy] Failed to register vault handlers:', err);
+  // Register vault handlers only if DB init succeeded
+  if (vaultReady) {
+    try {
+      registerVaultHandlers({ getMainWindow });
+      console.log('[Dorothy] Vault handlers registered successfully');
+    } catch (err) {
+      console.error('[Dorothy] Failed to register vault handlers:', err);
+    }
+  } else {
+    console.warn('[Dorothy] Vault handlers skipped due to database initialization failure');
   }
 
   // Register world (generative zone) handlers

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -89,7 +89,7 @@ import { registerSchedulerHandlers } from './handlers/scheduler-handlers';
 import { registerAutomationHandlers } from './handlers/automation-handlers';
 import { registerCLIPathsHandlers } from './handlers/cli-paths-handlers';
 import { registerKanbanHandlers } from './handlers/kanban-handlers';
-import { registerVaultHandlers } from './handlers/vault-handlers';
+import { registerVaultHandlers, registerLocalFileHandlers } from './handlers/vault-handlers';
 import { registerWorldHandlers } from './handlers/world-handlers';
 import { initVaultDb, closeVaultDb } from './services/vault-db';
 import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
@@ -403,7 +403,7 @@ app.whenReady().then(async () => {
     console.error('[Dorothy] Failed to initialize vault database:', err);
   }
 
-  // Register vault handlers only if DB init succeeded
+  // Register vault DB handlers only if DB init succeeded
   if (vaultReady) {
     try {
       registerVaultHandlers({ getMainWindow });
@@ -412,7 +412,15 @@ app.whenReady().then(async () => {
       console.error('[Dorothy] Failed to register vault handlers:', err);
     }
   } else {
-    console.warn('[Dorothy] Vault handlers skipped due to database initialization failure');
+    console.warn('[Dorothy] Vault DB handlers skipped due to database initialization failure');
+  }
+
+  // Register local file handlers (no DB dependency)
+  try {
+    registerLocalFileHandlers();
+    console.log('[Dorothy] Local file handlers registered successfully');
+  } catch (err) {
+    console.error('[Dorothy] Failed to register local file handlers:', err);
   }
 
   // Register world (generative zone) handlers

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -512,6 +512,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('vault:readLocalFile', filePath) as Promise<{ content?: string; filename?: string; filePath?: string; error?: string }>,
     writeLocalFile: (params: { filePath: string; content: string }) =>
       ipcRenderer.invoke('vault:writeLocalFile', params) as Promise<{ success?: boolean; filePath?: string; error?: string }>,
+    saveClipboardImage: (params: { imageDataUrl: string; targetDir?: string }) =>
+      ipcRenderer.invoke('vault:saveClipboardImage', params) as Promise<{ success?: boolean; filePath?: string; filename?: string; error?: string }>,
     // Event listeners
     onDocumentCreated: (callback: (doc: unknown) => void) => {
       const listener = (_: unknown, doc: unknown) => callback(doc);

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -508,6 +508,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('vault:deleteFolder', params),
     attachFile: (params: { document_id: string; file_path: string }) =>
       ipcRenderer.invoke('vault:attachFile', params),
+    readLocalFile: (filePath: string) =>
+      ipcRenderer.invoke('vault:readLocalFile', filePath) as Promise<{ content?: string; filename?: string; filePath?: string; error?: string }>,
+    writeLocalFile: (params: { filePath: string; content: string }) =>
+      ipcRenderer.invoke('vault:writeLocalFile', params) as Promise<{ success?: boolean; filePath?: string; error?: string }>,
     // Event listeners
     onDocumentCreated: (callback: (doc: unknown) => void) => {
       const listener = (_: unknown, doc: unknown) => callback(doc);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dorothy",
-  "version": "1.2.1",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dorothy",
-      "version": "1.2.1",
+      "version": "1.2.5",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@dnd-kit/core": "^6.3.1",

--- a/src/components/TerminalsView/components/FileEditorPanel.tsx
+++ b/src/components/TerminalsView/components/FileEditorPanel.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import { Save, X, Eye, Pencil } from 'lucide-react';
+
+interface FileEditorPanelProps {
+  filePath: string;
+  filename: string;
+  content: string;
+  onSave: (content: string) => void;
+  onClose: () => void;
+}
+
+type EditorTab = 'write' | 'preview';
+
+export default function FileEditorPanel({ filePath, filename, content: initialContent, onSave, onClose }: FileEditorPanelProps) {
+  const [content, setContent] = useState(initialContent);
+  const [activeTab, setActiveTab] = useState<EditorTab>('write');
+  const [saved, setSaved] = useState(true);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleChange = useCallback((value: string) => {
+    setContent(value);
+    setSaved(false);
+  }, []);
+
+  const handleSave = useCallback(() => {
+    onSave(content);
+    setSaved(true);
+  }, [content, onSave]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+      e.preventDefault();
+      handleSave();
+    }
+  }, [handleSave]);
+
+  return (
+    <div
+      className="flex flex-col h-full overflow-hidden border-t border-border"
+      onKeyDown={handleKeyDown}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-1.5 bg-secondary border-b border-border select-none shrink-0">
+        <span className="text-xs font-medium text-foreground truncate flex-1" title={filePath}>
+          {filename}
+        </span>
+        {!saved && (
+          <span className="text-[10px] text-amber-400 font-medium">modified</span>
+        )}
+
+        {/* Tab toggle */}
+        <div className="flex items-center bg-secondary/50 rounded p-0.5">
+          <button
+            onClick={() => setActiveTab('write')}
+            className={`p-1 rounded text-[10px] ${activeTab === 'write' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Edit"
+          >
+            <Pencil className="w-3 h-3" />
+          </button>
+          <button
+            onClick={() => setActiveTab('preview')}
+            className={`p-1 rounded text-[10px] ${activeTab === 'preview' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Preview"
+          >
+            <Eye className="w-3 h-3" />
+          </button>
+        </div>
+
+        <button
+          onClick={handleSave}
+          disabled={saved}
+          className="p-1 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30"
+          title="Save (⌘S)"
+        >
+          <Save className="w-3 h-3" />
+        </button>
+        <button
+          onClick={onClose}
+          className="p-1 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-red-400"
+          title="Close file"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      </div>
+
+      {/* Content */}
+      {activeTab === 'write' ? (
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={(e) => handleChange(e.target.value)}
+          className="flex-1 w-full text-xs bg-[#1a1a2e] text-foreground font-mono p-3 outline-none border-none resize-none leading-relaxed"
+          spellCheck={false}
+        />
+      ) : (
+        <div className="flex-1 overflow-y-auto p-3 text-xs text-foreground bg-[#1a1a2e]">
+          <pre className="whitespace-pre-wrap font-mono">{content}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TerminalsView/components/FileEditorPanel.tsx
+++ b/src/components/TerminalsView/components/FileEditorPanel.tsx
@@ -58,7 +58,7 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
           if (!window.electronAPI?.vault?.saveClipboardImage) return;
 
           // Save to same directory as the file being edited
-          const dirPath = filePath.split('/').slice(0, -1).join('/');
+          const dirPath = filePath.replace(/\\/g, '/').split('/').slice(0, -1).join('/');
           const result = await window.electronAPI.vault.saveClipboardImage({
             imageDataUrl: dataUrl,
             targetDir: dirPath || undefined,
@@ -70,8 +70,10 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
             const start = textarea.selectionStart;
             const end = textarea.selectionEnd;
             const mdImage = `![${result.filename}](${result.filePath})`;
-            const newContent = content.slice(0, start) + mdImage + content.slice(end);
-            setContent(newContent);
+            setContent(prev => {
+              const newContent = prev.slice(0, start) + mdImage + prev.slice(end);
+              return newContent;
+            });
             setSaved(false);
 
             const newPos = start + mdImage.length;
@@ -85,7 +87,7 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
         return;
       }
     }
-  }, [content, filePath]);
+  }, [filePath]);
 
   return (
     <div

--- a/src/components/TerminalsView/components/FileEditorPanel.tsx
+++ b/src/components/TerminalsView/components/FileEditorPanel.tsx
@@ -40,6 +40,53 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
     }
   }, [handleSave]);
 
+  // Handle paste with image support
+  const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const blob = item.getAsFile();
+        if (!blob) return;
+
+        // Convert to data URL
+        const reader = new FileReader();
+        reader.onload = async () => {
+          const dataUrl = reader.result as string;
+          if (!window.electronAPI?.vault?.saveClipboardImage) return;
+
+          // Save to same directory as the file being edited
+          const dirPath = filePath.split('/').slice(0, -1).join('/');
+          const result = await window.electronAPI.vault.saveClipboardImage({
+            imageDataUrl: dataUrl,
+            targetDir: dirPath || undefined,
+          });
+
+          if (result.success && result.filePath && result.filename) {
+            const textarea = textareaRef.current;
+            if (!textarea) return;
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            const mdImage = `![${result.filename}](${result.filePath})`;
+            const newContent = content.slice(0, start) + mdImage + content.slice(end);
+            setContent(newContent);
+            setSaved(false);
+
+            const newPos = start + mdImage.length;
+            requestAnimationFrame(() => {
+              textarea.focus();
+              textarea.setSelectionRange(newPos, newPos);
+            });
+          }
+        };
+        reader.readAsDataURL(blob);
+        return;
+      }
+    }
+  }, [content, filePath]);
+
   return (
     <div
       className={`flex flex-col h-full overflow-hidden ${position === 'top' || position === 'bottom' ? 'border-t border-b' : 'border-l border-r'} border-border`}
@@ -129,6 +176,7 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
           ref={textareaRef}
           value={content}
           onChange={(e) => handleChange(e.target.value)}
+          onPaste={handlePaste}
           className="flex-1 w-full text-xs bg-[#1a1a2e] text-foreground font-mono p-3 outline-none border-none resize-none leading-relaxed"
           spellCheck={false}
         />

--- a/src/components/TerminalsView/components/FileEditorPanel.tsx
+++ b/src/components/TerminalsView/components/FileEditorPanel.tsx
@@ -1,19 +1,23 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
-import { Save, X, Eye, Pencil } from 'lucide-react';
+import { Save, X, Eye, Pencil, PanelTop, PanelBottom, PanelLeft, PanelRight } from 'lucide-react';
+
+export type DockPosition = 'top' | 'bottom' | 'left' | 'right';
 
 interface FileEditorPanelProps {
   filePath: string;
   filename: string;
   content: string;
+  position: DockPosition;
   onSave: (content: string) => void;
   onClose: () => void;
+  onPositionChange: (position: DockPosition) => void;
 }
 
 type EditorTab = 'write' | 'preview';
 
-export default function FileEditorPanel({ filePath, filename, content: initialContent, onSave, onClose }: FileEditorPanelProps) {
+export default function FileEditorPanel({ filePath, filename, content: initialContent, position, onSave, onClose, onPositionChange }: FileEditorPanelProps) {
   const [content, setContent] = useState(initialContent);
   const [activeTab, setActiveTab] = useState<EditorTab>('write');
   const [saved, setSaved] = useState(true);
@@ -38,52 +42,84 @@ export default function FileEditorPanel({ filePath, filename, content: initialCo
 
   return (
     <div
-      className="flex flex-col h-full overflow-hidden border-t border-border"
+      className={`flex flex-col h-full overflow-hidden ${position === 'top' || position === 'bottom' ? 'border-t border-b' : 'border-l border-r'} border-border`}
       onKeyDown={handleKeyDown}
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-1.5 bg-secondary border-b border-border select-none shrink-0">
-        <span className="text-xs font-medium text-foreground truncate flex-1" title={filePath}>
+      <div className="flex items-center gap-1 px-2 py-1 bg-secondary border-b border-border select-none shrink-0">
+        <span className="text-[10px] font-medium text-foreground truncate flex-1" title={filePath}>
           {filename}
         </span>
         {!saved && (
-          <span className="text-[10px] text-amber-400 font-medium">modified</span>
+          <span className="text-[9px] text-amber-400 font-medium">modified</span>
         )}
 
         {/* Tab toggle */}
         <div className="flex items-center bg-secondary/50 rounded p-0.5">
           <button
             onClick={() => setActiveTab('write')}
-            className={`p-1 rounded text-[10px] ${activeTab === 'write' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            className={`p-0.5 rounded ${activeTab === 'write' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
             title="Edit"
           >
-            <Pencil className="w-3 h-3" />
+            <Pencil className="w-2.5 h-2.5" />
           </button>
           <button
             onClick={() => setActiveTab('preview')}
-            className={`p-1 rounded text-[10px] ${activeTab === 'preview' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            className={`p-0.5 rounded ${activeTab === 'preview' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
             title="Preview"
           >
-            <Eye className="w-3 h-3" />
+            <Eye className="w-2.5 h-2.5" />
+          </button>
+        </div>
+
+        {/* Position buttons */}
+        <div className="flex items-center bg-secondary/50 rounded p-0.5">
+          <button
+            onClick={() => onPositionChange('top')}
+            className={`p-0.5 rounded ${position === 'top' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Dock top"
+          >
+            <PanelTop className="w-2.5 h-2.5" />
+          </button>
+          <button
+            onClick={() => onPositionChange('bottom')}
+            className={`p-0.5 rounded ${position === 'bottom' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Dock bottom"
+          >
+            <PanelBottom className="w-2.5 h-2.5" />
+          </button>
+          <button
+            onClick={() => onPositionChange('left')}
+            className={`p-0.5 rounded ${position === 'left' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Dock left"
+          >
+            <PanelLeft className="w-2.5 h-2.5" />
+          </button>
+          <button
+            onClick={() => onPositionChange('right')}
+            className={`p-0.5 rounded ${position === 'right' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+            title="Dock right"
+          >
+            <PanelRight className="w-2.5 h-2.5" />
           </button>
         </div>
 
         <button
           onClick={handleSave}
           disabled={saved}
-          className="p-1 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30"
+          className="p-0.5 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-foreground disabled:opacity-30"
           title="Save (⌘S)"
         >
-          <Save className="w-3 h-3" />
+          <Save className="w-2.5 h-2.5" />
         </button>
         <button
           onClick={onClose}
-          className="p-1 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-red-400"
+          className="p-0.5 hover:bg-primary/10 transition-colors text-muted-foreground hover:text-red-400"
           title="Close file"
         >
-          <X className="w-3 h-3" />
+          <X className="w-2.5 h-2.5" />
         </button>
       </div>
 

--- a/src/components/TerminalsView/components/TerminalGrid.tsx
+++ b/src/components/TerminalsView/components/TerminalGrid.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from 'lucide-react';
 import type { AgentStatus } from '@/types/electron';
 import type { TerminalPanelState } from '../types';
 import TerminalPanel from './TerminalPanel';
+import type { OpenedFile } from './TerminalPanel';
 
 interface TerminalGridProps {
   agents: AgentStatus[];
@@ -21,6 +22,7 @@ interface TerminalGridProps {
   isLoading: boolean;
   isEditable: boolean;
   tabType: 'custom' | 'project';
+  openedFiles: Map<string, OpenedFile>;
   onRegisterContainer: (agentId: string, container: HTMLDivElement | null) => void;
   onStartAgent: (agentId: string) => void;
   onStopAgent: (agentId: string) => void;
@@ -31,6 +33,9 @@ interface TerminalGridProps {
   onFocusPanel: (agentId: string) => void;
   onContextMenu: (e: React.MouseEvent, agentId: string) => void;
   onFitAll: () => void;
+  onOpenFile: (agentId: string) => void;
+  onCloseFile: (agentId: string) => void;
+  onSaveFile: (agentId: string, content: string) => void;
 }
 
 export default function TerminalGrid({
@@ -46,6 +51,7 @@ export default function TerminalGrid({
   isLoading,
   isEditable,
   tabType,
+  openedFiles,
   onRegisterContainer,
   onStartAgent,
   onStopAgent,
@@ -56,6 +62,9 @@ export default function TerminalGrid({
   onFocusPanel,
   onContextMenu,
   onFitAll,
+  onOpenFile,
+  onCloseFile,
+  onSaveFile,
 }: TerminalGridProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
@@ -180,6 +189,7 @@ export default function TerminalGrid({
             isBroadcasting={broadcastMode}
             isFocused={true}
             tabType={tabType}
+            openedFile={openedFiles.get(panel.agentId)}
             onRegisterContainer={onRegisterContainer}
             onStart={onStartAgent}
             onStop={onStopAgent}
@@ -189,6 +199,9 @@ export default function TerminalGrid({
             onExitFullscreen={onExitFullscreen}
             onFocus={onFocusPanel}
             onContextMenu={onContextMenu}
+            onOpenFile={onOpenFile}
+            onCloseFile={onCloseFile}
+            onSaveFile={onSaveFile}
           />
         </div>
       );
@@ -221,6 +234,7 @@ export default function TerminalGrid({
                 isBroadcasting={broadcastMode}
                 isFocused={focusedPanelId === panel.agentId}
                 tabType={tabType}
+                openedFile={openedFiles.get(panel.agentId)}
                 onRegisterContainer={onRegisterContainer}
                 onStart={onStartAgent}
                 onStop={onStopAgent}
@@ -230,6 +244,9 @@ export default function TerminalGrid({
                 onExitFullscreen={onExitFullscreen}
                 onFocus={onFocusPanel}
                 onContextMenu={onContextMenu}
+                onOpenFile={onOpenFile}
+                onCloseFile={onCloseFile}
+                onSaveFile={onSaveFile}
               />
             </div>
           );

--- a/src/components/TerminalsView/components/TerminalPanel.tsx
+++ b/src/components/TerminalsView/components/TerminalPanel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import type { AgentStatus } from '@/types/electron';
 import TerminalPanelHeader from './TerminalPanelHeader';
 import FileEditorPanel from './FileEditorPanel';
+import type { DockPosition } from './FileEditorPanel';
 
 export interface OpenedFile {
   filePath: string;
@@ -86,6 +87,47 @@ export default function TerminalPanel({
   const handleCloseFile = useCallback(() => onCloseFile(agent.id), [agent.id, onCloseFile]);
   const handleSaveFile = useCallback((content: string) => onSaveFile(agent.id, content), [agent.id, onSaveFile]);
 
+  // Resizable split: file editor ratio (0..1, percentage of container for the editor)
+  const [editorRatio, setEditorRatio] = useState(0.5);
+  const [dockPosition, setDockPosition] = useState<DockPosition>('top');
+  const splitContainerRef = useRef<HTMLDivElement>(null);
+  const isDraggingRef = useRef(false);
+
+  const isVertical = dockPosition === 'top' || dockPosition === 'bottom';
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    isDraggingRef.current = true;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!isDraggingRef.current || !splitContainerRef.current) return;
+      const rect = splitContainerRef.current.getBoundingClientRect();
+      let ratio: number;
+      if (isVertical) {
+        const y = ev.clientY - rect.top;
+        ratio = y / rect.height;
+      } else {
+        const x = ev.clientX - rect.left;
+        ratio = x / rect.width;
+      }
+      // For bottom/right, we invert since editor comes after terminal
+      if (dockPosition === 'bottom' || dockPosition === 'right') {
+        ratio = 1 - ratio;
+      }
+      setEditorRatio(Math.min(0.8, Math.max(0.2, ratio)));
+    };
+
+    const onMouseUp = () => {
+      isDraggingRef.current = false;
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [isVertical, dockPosition]);
+
   return (
     <div
       ref={setDropRef}
@@ -114,24 +156,71 @@ export default function TerminalPanel({
         onOpenFile={handleOpenFile}
       />
 
-      {/* Terminal body + optional file editor — vertical stack */}
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-        {openedFile && (
-          <div className="h-1/2 min-h-0 overflow-hidden">
-            <FileEditorPanel
-              filePath={openedFile.filePath}
-              filename={openedFile.filename}
-              content={openedFile.content}
-              onSave={handleSaveFile}
-              onClose={handleCloseFile}
-            />
-          </div>
+      {/* Terminal body + optional file editor — resizable split */}
+      <div
+        ref={splitContainerRef}
+        className={`flex-1 min-h-0 flex overflow-hidden ${openedFile && isVertical ? 'flex-col' : openedFile ? 'flex-row' : 'flex-col'}`}
+      >
+        {/* Editor before terminal (top or left) */}
+        {openedFile && (dockPosition === 'top' || dockPosition === 'left') && (
+          <>
+            <div
+              className="min-h-0 min-w-0 overflow-hidden"
+              style={isVertical ? { height: `${editorRatio * 100}%` } : { width: `${editorRatio * 100}%` }}
+            >
+              <FileEditorPanel
+                filePath={openedFile.filePath}
+                filename={openedFile.filename}
+                content={openedFile.content}
+                position={dockPosition}
+                onSave={handleSaveFile}
+                onClose={handleCloseFile}
+                onPositionChange={setDockPosition}
+              />
+            </div>
+            <div
+              className={`${isVertical ? 'h-1.5 cursor-row-resize' : 'w-1.5 cursor-col-resize'} bg-border hover:bg-primary/50 flex items-center justify-center shrink-0 transition-colors`}
+              onMouseDown={handleResizeStart}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className={`${isVertical ? 'w-8 h-0.5' : 'h-8 w-0.5'} bg-muted-foreground/30 rounded-full`} />
+            </div>
+          </>
         )}
+
+        {/* Terminal */}
         <div
           ref={containerRef}
-          className={`min-h-0 overflow-hidden relative ${openedFile ? 'h-1/2' : 'flex-1'}`}
+          className="min-h-0 min-w-0 overflow-hidden relative flex-1"
           style={{ backgroundColor: '#1a1a2e' }}
         />
+
+        {/* Editor after terminal (bottom or right) */}
+        {openedFile && (dockPosition === 'bottom' || dockPosition === 'right') && (
+          <>
+            <div
+              className={`${isVertical ? 'h-1.5 cursor-row-resize' : 'w-1.5 cursor-col-resize'} bg-border hover:bg-primary/50 flex items-center justify-center shrink-0 transition-colors`}
+              onMouseDown={handleResizeStart}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className={`${isVertical ? 'w-8 h-0.5' : 'h-8 w-0.5'} bg-muted-foreground/30 rounded-full`} />
+            </div>
+            <div
+              className="min-h-0 min-w-0 overflow-hidden"
+              style={isVertical ? { height: `${editorRatio * 100}%` } : { width: `${editorRatio * 100}%` }}
+            >
+              <FileEditorPanel
+                filePath={openedFile.filePath}
+                filename={openedFile.filename}
+                content={openedFile.content}
+                position={dockPosition}
+                onSave={handleSaveFile}
+                onClose={handleCloseFile}
+                onPositionChange={setDockPosition}
+              />
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/TerminalsView/components/TerminalPanel.tsx
+++ b/src/components/TerminalsView/components/TerminalPanel.tsx
@@ -4,6 +4,13 @@ import { useRef, useEffect, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import type { AgentStatus } from '@/types/electron';
 import TerminalPanelHeader from './TerminalPanelHeader';
+import FileEditorPanel from './FileEditorPanel';
+
+export interface OpenedFile {
+  filePath: string;
+  filename: string;
+  content: string;
+}
 
 interface TerminalPanelProps {
   agent: AgentStatus;
@@ -11,6 +18,7 @@ interface TerminalPanelProps {
   isBroadcasting: boolean;
   isFocused: boolean;
   tabType: 'custom' | 'project';
+  openedFile?: OpenedFile | null;
   onRegisterContainer: (agentId: string, container: HTMLDivElement | null) => void;
   onStart: (agentId: string) => void;
   onStop: (agentId: string) => void;
@@ -20,6 +28,9 @@ interface TerminalPanelProps {
   onExitFullscreen: () => void;
   onFocus: (agentId: string) => void;
   onContextMenu: (e: React.MouseEvent, agentId: string) => void;
+  onOpenFile: (agentId: string) => void;
+  onCloseFile: (agentId: string) => void;
+  onSaveFile: (agentId: string, content: string) => void;
 }
 
 export default function TerminalPanel({
@@ -28,6 +39,7 @@ export default function TerminalPanel({
   isBroadcasting,
   isFocused,
   tabType,
+  openedFile,
   onRegisterContainer,
   onStart,
   onStop,
@@ -37,6 +49,9 @@ export default function TerminalPanel({
   onExitFullscreen,
   onFocus,
   onContextMenu,
+  onOpenFile,
+  onCloseFile,
+  onSaveFile,
 }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const onRegisterRef = useRef(onRegisterContainer);
@@ -67,6 +82,9 @@ export default function TerminalPanel({
   const handleClear = useCallback(() => onClear(agent.id), [agent.id, onClear]);
   const handleFullscreen = useCallback(() => onFullscreen(agent.id), [agent.id, onFullscreen]);
   const handleContextMenu = useCallback((e: React.MouseEvent) => onContextMenu(e, agent.id), [agent.id, onContextMenu]);
+  const handleOpenFile = useCallback(() => onOpenFile(agent.id), [agent.id, onOpenFile]);
+  const handleCloseFile = useCallback(() => onCloseFile(agent.id), [agent.id, onCloseFile]);
+  const handleSaveFile = useCallback((content: string) => onSaveFile(agent.id, content), [agent.id, onSaveFile]);
 
   return (
     <div
@@ -85,6 +103,7 @@ export default function TerminalPanel({
         isFullscreen={isFullscreen}
         isBroadcasting={isBroadcasting}
         tabType={tabType}
+        hasOpenFile={!!openedFile}
         onStart={handleStart}
         onStop={handleStop}
         onFullscreen={handleFullscreen}
@@ -92,14 +111,28 @@ export default function TerminalPanel({
         onClear={handleClear}
         onRemove={handleRemove}
         onContextMenu={handleContextMenu}
+        onOpenFile={handleOpenFile}
       />
 
-      {/* Terminal body */}
-      <div
-        ref={containerRef}
-        className="flex-1 min-h-0 overflow-hidden relative"
-        style={{ backgroundColor: '#1a1a2e' }}
-      />
+      {/* Terminal body + optional file editor — vertical stack */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {openedFile && (
+          <div className="h-1/2 min-h-0 overflow-hidden">
+            <FileEditorPanel
+              filePath={openedFile.filePath}
+              filename={openedFile.filename}
+              content={openedFile.content}
+              onSave={handleSaveFile}
+              onClose={handleCloseFile}
+            />
+          </div>
+        )}
+        <div
+          ref={containerRef}
+          className={`min-h-0 overflow-hidden relative ${openedFile ? 'h-1/2' : 'flex-1'}`}
+          style={{ backgroundColor: '#1a1a2e' }}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/TerminalsView/components/TerminalPanelHeader.tsx
+++ b/src/components/TerminalsView/components/TerminalPanelHeader.tsx
@@ -9,6 +9,7 @@ import {
   RotateCcw,
   GripVertical,
   ShieldOff,
+  FileEdit,
 } from 'lucide-react';
 import type { AgentStatus } from '@/types/electron';
 import { CHARACTER_FACES, STATUS_COLORS } from '../constants';
@@ -18,6 +19,7 @@ interface TerminalPanelHeaderProps {
   isFullscreen: boolean;
   isBroadcasting: boolean;
   tabType: 'custom' | 'project';
+  hasOpenFile?: boolean;
   onStart: () => void;
   onStop: () => void;
   onFullscreen: () => void;
@@ -25,6 +27,7 @@ interface TerminalPanelHeaderProps {
   onClear: () => void;
   onRemove: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
+  onOpenFile: () => void;
 }
 
 export default function TerminalPanelHeader({
@@ -32,6 +35,7 @@ export default function TerminalPanelHeader({
   isFullscreen,
   isBroadcasting,
   tabType,
+  hasOpenFile,
   onStart,
   onStop,
   onFullscreen,
@@ -39,6 +43,7 @@ export default function TerminalPanelHeader({
   onClear,
   onRemove,
   onContextMenu,
+  onOpenFile,
 }: TerminalPanelHeaderProps) {
   const emoji = agent.name?.toLowerCase() === 'bitwonka'
     ? '🐸'
@@ -122,6 +127,14 @@ export default function TerminalPanelHeader({
           title="Clear terminal"
         >
           <RotateCcw className="w-3 h-3" />
+        </button>
+
+        <button
+          onClick={onOpenFile}
+          className={`p-1 hover:bg-primary/10 transition-colors ${hasOpenFile ? 'text-cyan-400' : 'text-muted-foreground hover:text-foreground'}`}
+          title={hasOpenFile ? 'File open' : 'Open file'}
+        >
+          <FileEdit className="w-3 h-3" />
         </button>
 
         <button

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -48,6 +48,7 @@ export default function TerminalsView() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [viewFullscreen, setViewFullscreen] = useState(false);
   const [terminalFontSize, setTerminalFontSize] = useState(11);
+  const [openedFiles, setOpenedFiles] = useState<Map<string, { filePath: string; filename: string; content: string }>>(new Map());
   const pendingStartRef = useRef<{ agentId: string; prompt: string; options?: { model?: string } } | null>(null);
   const [terminalTheme, setTerminalTheme] = useState<'dark' | 'light'>('dark');
   const [terminalSettingsLoaded, setTerminalSettingsLoaded] = useState(!isElectron());
@@ -230,6 +231,69 @@ export default function TerminalsView() {
     }
   }, [agents]);
 
+  // File editor handlers
+  const handleOpenFile = useCallback(async (agentId: string) => {
+    if (!isElectron() || !window.electronAPI?.dialog || !window.electronAPI?.vault) return;
+    // If already open, close it
+    if (openedFiles.has(agentId)) {
+      setOpenedFiles(prev => {
+        const next = new Map(prev);
+        next.delete(agentId);
+        return next;
+      });
+      setTimeout(() => multiTerminal.fitAll(), 100);
+      return;
+    }
+    try {
+      const filePaths = await window.electronAPI.dialog.openFiles();
+      if (!filePaths || filePaths.length === 0) return;
+      const result = await window.electronAPI.vault.readLocalFile(filePaths[0]);
+      if (result.error) {
+        alert(result.error);
+        return;
+      }
+      if (result.content === undefined) return;
+      setOpenedFiles(prev => {
+        const next = new Map(prev);
+        next.set(agentId, {
+          filePath: result.filePath || filePaths[0],
+          filename: result.filename || filePaths[0].split('/').pop() || 'file',
+          content: result.content!,
+        });
+        return next;
+      });
+      setTimeout(() => multiTerminal.fitAll(), 100);
+    } catch (err) {
+      console.error('Failed to open file:', err);
+    }
+  }, [openedFiles, multiTerminal]);
+
+  const handleCloseFile = useCallback((agentId: string) => {
+    setOpenedFiles(prev => {
+      const next = new Map(prev);
+      next.delete(agentId);
+      return next;
+    });
+    setTimeout(() => multiTerminal.fitAll(), 100);
+  }, [multiTerminal]);
+
+  const handleSaveFile = useCallback(async (agentId: string, content: string) => {
+    if (!isElectron() || !window.electronAPI?.vault) return;
+    const file = openedFiles.get(agentId);
+    if (!file) return;
+    try {
+      const result = await window.electronAPI.vault.writeLocalFile({
+        filePath: file.filePath,
+        content,
+      });
+      if (!result.success) {
+        console.error('Failed to save file:', result.error);
+      }
+    } catch (err) {
+      console.error('Failed to save file:', err);
+    }
+  }, [openedFiles]);
+
   const handleLayoutChange = useCallback((preset: LayoutPreset) => {
     if (tabManager.activeCustomTab) {
       tabManager.setTabLayout(tabManager.activeCustomTab.id, preset);
@@ -358,6 +422,7 @@ export default function TerminalsView() {
             isLoading={isLoading}
             isEditable={isEditable}
             tabType={tabType}
+            openedFiles={openedFiles}
             onRegisterContainer={multiTerminal.registerContainer}
             onStartAgent={handleStartAgent}
             onStopAgent={handleStopAgent}
@@ -368,6 +433,9 @@ export default function TerminalsView() {
             onFocusPanel={handleFocusPanel}
             onContextMenu={contextMenu.openMenu}
             onFitAll={multiTerminal.fitAll}
+            onOpenFile={handleOpenFile}
+            onCloseFile={handleCloseFile}
+            onSaveFile={handleSaveFile}
           />
 
           {/* Sidebar panel — overlays grid from the right */}

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -277,7 +277,10 @@ export default function TerminalsView() {
         filePath: file.filePath,
         content,
       });
-      if (!result.success) {
+      if (result.success) {
+        // Update store content so remounts don't rehydrate stale text
+        setOpenedFile(agentId, { ...file, content });
+      } else {
         console.error('Failed to save file:', result.error);
         alert(`Failed to save file: ${result.error || 'Unknown error'}`);
       }
@@ -285,7 +288,7 @@ export default function TerminalsView() {
       console.error('Failed to save file:', err);
       alert(`Failed to save file: ${String(err)}`);
     }
-  }, [openedFiles]);
+  }, [openedFiles, setOpenedFile]);
 
   const handleLayoutChange = useCallback((preset: LayoutPreset) => {
     if (tabManager.activeCustomTab) {

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -279,9 +279,11 @@ export default function TerminalsView() {
       });
       if (!result.success) {
         console.error('Failed to save file:', result.error);
+        alert(`Failed to save file: ${result.error || 'Unknown error'}`);
       }
     } catch (err) {
       console.error('Failed to save file:', err);
+      alert(`Failed to save file: ${String(err)}`);
     }
   }, [openedFiles]);
 

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { isElectron } from '@/hooks/useElectron';
 import { DndContext } from '@dnd-kit/core';
 import { useElectronAgents, useElectronFS, useElectronSkills } from '@/hooks/useElectron';
+import { useOpenedFilesStore } from '@/store/openedFiles';
 import { useMultiTerminal } from './hooks/useMultiTerminal';
 import { useTerminalGrid } from './hooks/useTerminalGrid';
 import { useTabManager } from './hooks/useTabManager';
@@ -48,7 +49,9 @@ export default function TerminalsView() {
   const [panelOpen, setPanelOpen] = useState(false);
   const [viewFullscreen, setViewFullscreen] = useState(false);
   const [terminalFontSize, setTerminalFontSize] = useState(11);
-  const [openedFiles, setOpenedFiles] = useState<Map<string, { filePath: string; filename: string; content: string }>>(new Map());
+  const openedFiles = useOpenedFilesStore((s) => s.files);
+  const setOpenedFile = useOpenedFilesStore((s) => s.setFile);
+  const removeOpenedFile = useOpenedFilesStore((s) => s.removeFile);
   const pendingStartRef = useRef<{ agentId: string; prompt: string; options?: { model?: string } } | null>(null);
   const [terminalTheme, setTerminalTheme] = useState<'dark' | 'light'>('dark');
   const [terminalSettingsLoaded, setTerminalSettingsLoaded] = useState(!isElectron());
@@ -236,11 +239,7 @@ export default function TerminalsView() {
     if (!isElectron() || !window.electronAPI?.dialog || !window.electronAPI?.vault) return;
     // If already open, close it
     if (openedFiles.has(agentId)) {
-      setOpenedFiles(prev => {
-        const next = new Map(prev);
-        next.delete(agentId);
-        return next;
-      });
+      removeOpenedFile(agentId);
       setTimeout(() => multiTerminal.fitAll(), 100);
       return;
     }
@@ -253,29 +252,21 @@ export default function TerminalsView() {
         return;
       }
       if (result.content === undefined) return;
-      setOpenedFiles(prev => {
-        const next = new Map(prev);
-        next.set(agentId, {
-          filePath: result.filePath || filePaths[0],
-          filename: result.filename || filePaths[0].split('/').pop() || 'file',
-          content: result.content!,
-        });
-        return next;
+      setOpenedFile(agentId, {
+        filePath: result.filePath || filePaths[0],
+        filename: result.filename || filePaths[0].split('/').pop() || 'file',
+        content: result.content!,
       });
       setTimeout(() => multiTerminal.fitAll(), 100);
     } catch (err) {
       console.error('Failed to open file:', err);
     }
-  }, [openedFiles, multiTerminal]);
+  }, [openedFiles, multiTerminal, removeOpenedFile, setOpenedFile]);
 
   const handleCloseFile = useCallback((agentId: string) => {
-    setOpenedFiles(prev => {
-      const next = new Map(prev);
-      next.delete(agentId);
-      return next;
-    });
+    removeOpenedFile(agentId);
     setTimeout(() => multiTerminal.fitAll(), 100);
-  }, [multiTerminal]);
+  }, [multiTerminal, removeOpenedFile]);
 
   const handleSaveFile = useCallback(async (agentId: string, content: string) => {
     if (!isElectron() || !window.electronAPI?.vault) return;

--- a/src/components/VaultView/components/DocumentEditor.tsx
+++ b/src/components/VaultView/components/DocumentEditor.tsx
@@ -228,6 +228,42 @@ export default function DocumentEditor({ document, localFile, folders, defaultFo
     }
   };
 
+  // Handle paste with image support
+  const handleTextareaPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+
+    for (const item of Array.from(items)) {
+      if (item.type.startsWith('image/')) {
+        e.preventDefault();
+        const blob = item.getAsFile();
+        if (!blob) return;
+
+        const reader = new FileReader();
+        reader.onload = async () => {
+          const dataUrl = reader.result as string;
+          if (!window.electronAPI?.vault?.saveClipboardImage) return;
+
+          // For local files, save to same directory; for vault docs, use vault attachments
+          const targetDir = isLocalFile && localFile
+            ? localFile.filePath.split('/').slice(0, -1).join('/')
+            : undefined;
+
+          const result = await window.electronAPI.vault.saveClipboardImage({
+            imageDataUrl: dataUrl,
+            targetDir: targetDir || undefined,
+          });
+
+          if (result.success && result.filePath && result.filename) {
+            insertTextAtCursor(`![${result.filename}](${result.filePath})`);
+          }
+        };
+        reader.readAsDataURL(blob);
+        return;
+      }
+    }
+  };
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -405,6 +441,7 @@ export default function DocumentEditor({ document, localFile, folders, defaultFo
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
                 onKeyDown={handleTextareaKeyDown}
+                onPaste={handleTextareaPaste}
                 placeholder="Write your document content here..."
                 className="w-full min-h-[400px] text-sm bg-transparent outline-none !border-none text-foreground placeholder:text-muted-foreground/40 focus:outline-none resize-none leading-relaxed font-mono p-4"
                 style={{ height: 'calc(100vh - 380px)' }}

--- a/src/components/VaultView/components/DocumentEditor.tsx
+++ b/src/components/VaultView/components/DocumentEditor.tsx
@@ -130,19 +130,20 @@ export default function DocumentEditor({ document, localFile, folders, defaultFo
 
     const start = textarea.selectionStart;
     const end = textarea.selectionEnd;
-    const before = content.slice(0, start);
-    const after = content.slice(end);
-    const needsNewline = before.length > 0 && !before.endsWith('\n');
-    const insert = (needsNewline ? '\n' : '') + text + '\n';
-    const newContent = before + insert + after;
-    setContent(newContent);
+    setContent(prev => {
+      const before = prev.slice(0, start);
+      const after = prev.slice(end);
+      const needsNewline = before.length > 0 && !before.endsWith('\n');
+      const insert = (needsNewline ? '\n' : '') + text + '\n';
+      return before + insert + after;
+    });
 
-    const newPos = start + insert.length;
+    const newPos = start + text.length + 2; // approximate
     requestAnimationFrame(() => {
       textarea.focus();
       textarea.setSelectionRange(newPos, newPos);
     });
-  }, [content]);
+  }, []);
 
   const applyFormatting = useCallback((action: ToolbarAction) => {
     const textarea = textareaRef.current;

--- a/src/components/VaultView/components/DocumentEditor.tsx
+++ b/src/components/VaultView/components/DocumentEditor.tsx
@@ -246,7 +246,7 @@ export default function DocumentEditor({ document, localFile, folders, defaultFo
 
           // For local files, save to same directory; for vault docs, use vault attachments
           const targetDir = isLocalFile && localFile
-            ? localFile.filePath.split('/').slice(0, -1).join('/')
+            ? localFile.filePath.replace(/\\/g, '/').split('/').slice(0, -1).join('/')
             : undefined;
 
           const result = await window.electronAPI.vault.saveClipboardImage({

--- a/src/components/VaultView/components/DocumentEditor.tsx
+++ b/src/components/VaultView/components/DocumentEditor.tsx
@@ -29,6 +29,7 @@ import { SimpleMarkdown } from './MarkdownRenderer';
 
 interface DocumentEditorProps {
   document?: VaultDocumentElectron | null;
+  localFile?: { filePath: string; filename: string; content: string } | null;
   folders: VaultFolderElectron[];
   defaultFolderId?: string | null;
   onSave: (data: {
@@ -92,19 +93,20 @@ function getFileName(filepath: string): string {
   return filepath.split('/').pop()?.split('\\').pop() || 'file';
 }
 
-export default function DocumentEditor({ document, folders, defaultFolderId, onSave, onCancel }: DocumentEditorProps) {
-  const [title, setTitle] = useState(document?.title || '');
-  const [content, setContent] = useState(document?.content || '');
+export default function DocumentEditor({ document, localFile, folders, defaultFolderId, onSave, onCancel }: DocumentEditorProps) {
+  const isLocalFile = !!localFile;
+  const [title, setTitle] = useState(localFile?.filename || document?.title || '');
+  const [content, setContent] = useState(localFile?.content || document?.content || '');
   const [tagsInput, setTagsInput] = useState(document ? parseTags(document.tags).join(', ') : '');
   const [folderId, setFolderId] = useState<string | null>(document?.folder_id || defaultFolderId || null);
   const [activeTab, setActiveTab] = useState<EditorTab>('write');
   const [pendingFiles, setPendingFiles] = useState<string[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  const isNew = !document;
+  const isNew = !document && !localFile;
 
   const handleSave = () => {
-    if (!title.trim()) return;
+    if (!isLocalFile && !title.trim()) return;
     const tags = tagsInput.split(',').map(t => t.trim()).filter(Boolean);
     onSave({ title: title.trim(), content, tags, folder_id: folderId, pendingFiles });
   };
@@ -243,8 +245,13 @@ export default function DocumentEditor({ document, folders, defaultFolderId, onS
             <ArrowLeft className="w-4 h-4" />
           </button>
           <h2 className="font-semibold text-foreground">
-            {isNew ? 'New Document' : 'Edit Document'}
+            {isLocalFile ? 'Edit File' : isNew ? 'New Document' : 'Edit Document'}
           </h2>
+          {isLocalFile && localFile && (
+            <span className="text-xs text-muted-foreground truncate max-w-[300px]" title={localFile.filePath}>
+              {localFile.filePath}
+            </span>
+          )}
         </div>
 
         <div className="flex items-center gap-2">
@@ -256,11 +263,11 @@ export default function DocumentEditor({ document, folders, defaultFolderId, onS
           </button>
           <button
             onClick={handleSave}
-            disabled={!title.trim()}
+            disabled={!isLocalFile && !title.trim()}
             className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-foreground text-background rounded hover:bg-foreground/90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
           >
             <Save className="w-3.5 h-3.5" />
-            {isNew ? 'Create' : 'Save'}
+            {isLocalFile ? 'Save' : isNew ? 'Create' : 'Save'}
           </button>
         </div>
       </div>
@@ -268,17 +275,20 @@ export default function DocumentEditor({ document, folders, defaultFolderId, onS
       {/* Editor form */}
       <div className="flex-1 overflow-y-auto">
         <div className="px-4 lg:px-6 py-5 space-y-4">
-          {/* Title */}
-          <input
-            type="text"
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="Document title..."
-            className="w-full text-sm bg-secondary border border-border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
-            autoFocus
-          />
+          {/* Title — hidden for local files */}
+          {!isLocalFile && (
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Document title..."
+              className="w-full text-sm bg-secondary border border-border rounded px-2 py-1 focus:outline-none focus:ring-1 focus:ring-primary"
+              autoFocus
+            />
+          )}
 
-          {/* Meta row: folder + tags */}
+          {/* Meta row: folder + tags — hidden for local files */}
+          {!isLocalFile && (
           <div className="flex items-center gap-4 pb-4 border-b border-border">
             <div className="flex items-center gap-2 min-w-0">
               <FolderOpen className="w-4 h-4 text-muted-foreground shrink-0" />
@@ -305,6 +315,7 @@ export default function DocumentEditor({ document, folders, defaultFolderId, onS
               />
             </div>
           </div>
+          )}
 
           {/* Markdown editor */}
           <div className="border border-border rounded-lg overflow-hidden">
@@ -413,7 +424,7 @@ export default function DocumentEditor({ document, folders, defaultFolderId, onS
           </div>
 
           {/* Pending files indicator */}
-          {pendingFiles.length > 0 && (
+          {!isLocalFile && pendingFiles.length > 0 && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground px-1">
               <Paperclip className="w-3 h-3" />
               <span>{pendingFiles.length} file{pendingFiles.length !== 1 ? 's' : ''} will be attached on save</span>

--- a/src/components/VaultView/index.tsx
+++ b/src/components/VaultView/index.tsx
@@ -9,6 +9,7 @@ import {
   X,
   Archive,
   Loader2,
+  FileEdit,
 } from 'lucide-react';
 import type { VaultDocumentElectron, VaultFolderElectron, VaultAttachmentElectron } from '@/types/electron';
 
@@ -23,7 +24,7 @@ function isElectron(): boolean {
   return typeof window !== 'undefined' && !!window.electronAPI?.vault;
 }
 
-type ViewMode = 'list' | 'view' | 'edit' | 'search';
+type ViewMode = 'list' | 'view' | 'edit' | 'search' | 'edit-local';
 
 const READ_DOCS_KEY = 'vault-read-docs';
 
@@ -61,6 +62,7 @@ export default function VaultView({ embedded }: { embedded?: boolean } = {}) {
   const [searchQuery, setSearchQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [localFile, setLocalFile] = useState<{ filePath: string; filename: string; content: string } | null>(null);
   const setVaultUnreadCount = useStore(s => s.setVaultUnreadCount);
 
   // Sync unread count to global store for sidebar badge
@@ -279,6 +281,53 @@ export default function VaultView({ embedded }: { embedded?: boolean } = {}) {
     }
   };
 
+  // Open local file for editing
+  const handleOpenLocalFile = async () => {
+    if (!isElectron()) return;
+    try {
+      const filePaths = await window.electronAPI!.dialog.openFiles();
+      if (!filePaths || filePaths.length === 0) return;
+      const filePath = filePaths[0];
+      const result = await window.electronAPI!.vault!.readLocalFile(filePath);
+      if (result.error) {
+        alert(result.error);
+        return;
+      }
+      if (result.content === undefined) {
+        return;
+      }
+      setLocalFile({
+        filePath: result.filePath || filePath,
+        filename: result.filename || filePath.split('/').pop() || 'file',
+        content: result.content,
+      });
+      setSelectedDoc(null);
+      setViewMode('edit-local');
+    } catch (err) {
+      console.error('Failed to open local file:', err);
+    }
+  };
+
+  // Save local file
+  const handleSaveLocalFile = async (data: { content: string }) => {
+    if (!isElectron() || !localFile) return;
+    try {
+      const result = await window.electronAPI!.vault!.writeLocalFile({
+        filePath: localFile.filePath,
+        content: data.content,
+      });
+      if (result.success) {
+        setLocalFile(prev => prev ? { ...prev, content: data.content } : null);
+        setViewMode('list');
+        setLocalFile(null);
+      } else {
+        console.error('Failed to save file:', result.error);
+      }
+    } catch (err) {
+      console.error('Failed to save local file:', err);
+    }
+  };
+
   // Delete document
   const handleDeleteDocument = async (id: string) => {
     if (!isElectron()) return;
@@ -372,6 +421,15 @@ export default function VaultView({ embedded }: { embedded?: boolean } = {}) {
                 </button>
               )}
             </div>
+
+            {/* Open local file button */}
+            <button
+              onClick={handleOpenLocalFile}
+              className="flex items-center gap-1.5 px-3 lg:px-4 py-2 text-sm bg-secondary text-foreground border border-border rounded hover:bg-secondary/80 transition-colors shrink-0"
+            >
+              <FileEdit className="w-4 h-4" />
+              <span className="hidden sm:inline">Open File</span>
+            </button>
 
             {/* New document button */}
             <button
@@ -492,6 +550,26 @@ export default function VaultView({ embedded }: { embedded?: boolean } = {}) {
                     onSave={selectedDoc ? handleUpdateDocument : handleCreateDocument}
                     onCancel={() => {
                       setViewMode(selectedDoc ? 'view' : 'list');
+                    }}
+                  />
+                </motion.div>
+              )}
+
+              {viewMode === 'edit-local' && localFile && (
+                <motion.div
+                  key="edit-local"
+                  initial={{ opacity: 0, x: 10 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: 0.15 }}
+                  className="h-full overflow-y-auto"
+                >
+                  <DocumentEditor
+                    localFile={localFile}
+                    folders={folders}
+                    onSave={(_data) => handleSaveLocalFile({ content: _data.content })}
+                    onCancel={() => {
+                      setLocalFile(null);
+                      setViewMode('list');
                     }}
                   />
                 </motion.div>

--- a/src/store/openedFiles.ts
+++ b/src/store/openedFiles.ts
@@ -1,0 +1,35 @@
+import { create } from 'zustand';
+
+export interface OpenedFileEntry {
+  filePath: string;
+  filename: string;
+  content: string;
+}
+
+interface OpenedFilesState {
+  /** Map of agentId → opened file */
+  files: Map<string, OpenedFileEntry>;
+  setFile: (agentId: string, file: OpenedFileEntry) => void;
+  removeFile: (agentId: string) => void;
+  getFile: (agentId: string) => OpenedFileEntry | undefined;
+}
+
+export const useOpenedFilesStore = create<OpenedFilesState>((set, get) => ({
+  files: new Map(),
+
+  setFile: (agentId, file) =>
+    set((state) => {
+      const next = new Map(state.files);
+      next.set(agentId, file);
+      return { files: next };
+    }),
+
+  removeFile: (agentId) =>
+    set((state) => {
+      const next = new Map(state.files);
+      next.delete(agentId);
+      return { files: next };
+    }),
+
+  getFile: (agentId) => get().files.get(agentId),
+}));

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -706,6 +706,8 @@ export interface ElectronAPI {
     createFolder: (params: { name: string; parent_id?: string }) => Promise<{ success: boolean; folder?: VaultFolderElectron; error?: string }>;
     deleteFolder: (params: { id: string; recursive?: boolean }) => Promise<{ success: boolean; error?: string }>;
     attachFile: (params: { document_id: string; file_path: string }) => Promise<{ success: boolean; attachment?: VaultAttachmentElectron; error?: string }>;
+    readLocalFile: (filePath: string) => Promise<{ content?: string; filename?: string; filePath?: string; error?: string }>;
+    writeLocalFile: (params: { filePath: string; content: string }) => Promise<{ success?: boolean; filePath?: string; error?: string }>;
     onDocumentCreated: (callback: (doc: VaultDocumentElectron) => void) => () => void;
     onDocumentUpdated: (callback: (doc: VaultDocumentElectron) => void) => () => void;
     onDocumentDeleted: (callback: (event: { id: string }) => void) => () => void;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -708,6 +708,7 @@ export interface ElectronAPI {
     attachFile: (params: { document_id: string; file_path: string }) => Promise<{ success: boolean; attachment?: VaultAttachmentElectron; error?: string }>;
     readLocalFile: (filePath: string) => Promise<{ content?: string; filename?: string; filePath?: string; error?: string }>;
     writeLocalFile: (params: { filePath: string; content: string }) => Promise<{ success?: boolean; filePath?: string; error?: string }>;
+    saveClipboardImage: (params: { imageDataUrl: string; targetDir?: string }) => Promise<{ success?: boolean; filePath?: string; filename?: string; error?: string }>;
     onDocumentCreated: (callback: (doc: VaultDocumentElectron) => void) => () => void;
     onDocumentUpdated: (callback: (doc: VaultDocumentElectron) => void) => () => void;
     onDocumentDeleted: (callback: (event: { id: string }) => void) => () => void;


### PR DESCRIPTION
- Add readLocalFile/writeLocalFile IPC handlers for reading/writing local files
- Add binary file detection to prevent opening non-text files
- Add 'Open File' button in Vault to edit local files directly
- Add file editor split view in terminal panels (vertical layout)
- FileEditorPanel component with write/preview tabs and Cmd+S save
- Add error handling around vault DB initialization in main.ts

<img width="1185" height="783" alt="Capture d’écran 2026-03-25 à 22 26 55" src="https://github.com/user-attachments/assets/5c60f382-5aeb-478c-991f-a70f23cf653d" />
<img width="1185" height="783" alt="Capture d’écran 2026-03-25 à 22 27 08" src="https://github.com/user-attachments/assets/11cb819a-ac1e-4ce8-a6ae-7fb694185054" />
<img width="1185" height="783" alt="Capture d’écran 2026-03-25 à 22 27 31" src="https://github.com/user-attachments/assets/062a87e5-b999-4df6-9e29-c36d064fe817" />
<img width="1334" height="985" alt="Capture d’écran 2026-03-26 à 10 40 33" src="https://github.com/user-attachments/assets/3f70f406-c0ed-493a-93a4-4c37dbddfec3" />
<img width="1654" height="985" alt="Capture d’écran 2026-03-26 à 10 58 03" src="https://github.com/user-attachments/assets/530ffa1d-2a7f-4246-b17b-7b227edabf05" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dockable, resizable file editor in terminals with edit/preview tabs and Cmd/Ctrl+S save
  * Open local files into the vault editor ("edit local" mode) and save edits back to disk
  * Paste images from clipboard — automatically saved and inserted as Markdown links
  * Global opened-files state so terminals track per-agent open files
* **Other**
  * IPC-backed file operations for reading/writing local files and saving clipboard images
<!-- end of auto-generated comment: release notes by coderabbit.ai -->