### PR TITLE
feat: cycle through custom tabs with Ctrl+Tab

### DIFF
--- a/src/components/TerminalsView/hooks/useTerminalKeyboard.ts
+++ b/src/components/TerminalsView/hooks/useTerminalKeyboard.ts
@@ -10,6 +10,7 @@ interface UseTerminalKeyboardOptions {
   onToggleSidebar: () => void;
   onNewAgent: () => void;
   onExitFullscreen: () => void;
+  onCycleTab: (direction: 'next' | 'prev') => void;
   isFullscreen: boolean;
 }
 
@@ -21,9 +22,17 @@ export function useTerminalKeyboard({
   onToggleSidebar,
   onNewAgent,
   onExitFullscreen,
+  onCycleTab,
   isFullscreen,
 }: UseTerminalKeyboardOptions) {
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    // Ctrl+Tab / Ctrl+Shift+Tab: Cycle through custom tabs (browser-style)
+    if (e.ctrlKey && e.key === 'Tab') {
+      e.preventDefault();
+      onCycleTab(e.shiftKey ? 'prev' : 'next');
+      return;
+    }
+
     // Ctrl+1-9: Focus terminal by index
     if (e.ctrlKey && !e.shiftKey && e.key >= '1' && e.key <= '9') {
       const index = parseInt(e.key) - 1;
@@ -62,7 +71,7 @@ export function useTerminalKeyboard({
       e.preventDefault();
       onExitFullscreen();
     }
-  }, [panelAgentIds, onFocusPanel, onToggleFullscreen, onToggleBroadcast, onToggleSidebar, onNewAgent, onExitFullscreen, isFullscreen]);
+  }, [panelAgentIds, onFocusPanel, onToggleFullscreen, onToggleBroadcast, onToggleSidebar, onNewAgent, onExitFullscreen, onCycleTab, isFullscreen]);
 
   useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -52,6 +52,12 @@ export default function TerminalsView() {
   const pendingStartRef = useRef<{ agentId: string; prompt: string; options?: { model?: string } } | null>(null);
   const [terminalTheme, setTerminalTheme] = useState<'dark' | 'light'>('dark');
   const [terminalSettingsLoaded, setTerminalSettingsLoaded] = useState(!isElectron());
+  // Remember last focused agent per custom tab so Ctrl+Tab restores focus where the user left it
+  const lastFocusedByTabRef = useRef<Map<string, string>>(new Map());
+  // Set by handleCycleTab; consumed by handleTerminalReady once the destination
+  // tab's terminal finishes async init. Also consumed inline if the terminal is
+  // already mounted (fast tab cycling).
+  const pendingFocusRef = useRef<string | null>(null);
 
   // Load terminal settings from app settings
   useEffect(() => {
@@ -111,7 +117,12 @@ export default function TerminalsView() {
   // Agent IDs for grid
   const agentIds = useMemo(() => filteredAgents.map(a => a.id), [filteredAgents]);
 
+  // Set after multiTerminal is created; lets handleTerminalReady consume
+  // pendingFocusRef without a circular dep.
+  const focusTerminalRef = useRef<((agentId: string) => void) | null>(null);
+
   // Called when a terminal is fully initialized — fire any deferred agent start
+  // and consume any pending Ctrl+Tab focus targeting this agent.
   const handleTerminalReady = useCallback((agentId: string) => {
     const pending = pendingStartRef.current;
     if (pending && pending.agentId === agentId) {
@@ -119,6 +130,10 @@ export default function TerminalsView() {
       startAgent(pending.agentId, pending.prompt, pending.options as { model?: string; resume?: boolean }).catch(error => {
         console.error('Failed to start agent after creation:', error);
       });
+    }
+    if (pendingFocusRef.current === agentId) {
+      pendingFocusRef.current = null;
+      focusTerminalRef.current?.(agentId);
     }
   }, [startAgent]);
 
@@ -139,6 +154,18 @@ export default function TerminalsView() {
     onTerminalReady: handleTerminalReady,
     broadcastMode: broadcast.broadcastMode,
   });
+  // Expose focusTerminal to handleTerminalReady via a ref to break the cycle.
+  focusTerminalRef.current = multiTerminal.focusTerminal;
+
+  // Prune lastFocusedByTabRef entries for tabs that no longer exist (mirrors
+  // the cleanup useTabManager does for stale agent IDs and tab layouts).
+  useEffect(() => {
+    const validIds = new Set(tabManager.customTabs.map(t => t.id));
+    for (const tabId of lastFocusedByTabRef.current.keys()) {
+      if (!validIds.has(tabId)) lastFocusedByTabRef.current.delete(tabId);
+    }
+  }, [tabManager.customTabs]);
+
   const grid = useTerminalGrid({ agentIds, preset: gridPreset, isEditable, tabId });
   const search = useTerminalSearch(filteredAgents);
   const contextMenu = useTerminalContextMenu();
@@ -148,26 +175,6 @@ export default function TerminalsView() {
     onSkillDrop: async (skillName, agentId) => {
       await sendInput(agentId, `use this skill: ${skillName}\n`);
     },
-  });
-
-  // Keyboard shortcuts
-  const visibleAgentIds = useMemo(
-    () => grid.visiblePanels.map(p => p.agentId),
-    [grid.visiblePanels]
-  );
-
-  useTerminalKeyboard({
-    panelAgentIds: visibleAgentIds,
-    onFocusPanel: (agentId) => {
-      setFocusedPanelId(agentId);
-      multiTerminal.focusTerminal(agentId);
-    },
-    onToggleFullscreen: () => grid.toggleFullscreen(focusedPanelId || undefined),
-    onToggleBroadcast: broadcast.toggleBroadcast,
-    onToggleSidebar: () => { },
-    onNewAgent: () => setShowNewChatModal(true),
-    onExitFullscreen: grid.exitFullscreen,
-    isFullscreen: !!grid.fullscreenPanelId,
   });
 
   // Handler callbacks
@@ -209,7 +216,61 @@ export default function TerminalsView() {
   const handleFocusPanel = useCallback((agentId: string) => {
     setFocusedPanelId(agentId);
     multiTerminal.focusTerminal(agentId);
-  }, [multiTerminal]);
+    if (tabManager.isCustomTabActive && tabManager.activeCustomTab) {
+      lastFocusedByTabRef.current.set(tabManager.activeCustomTab.id, agentId);
+    }
+  }, [multiTerminal, tabManager]);
+
+  // Ctrl+Tab / Ctrl+Shift+Tab: cycle through custom tabs (browser-style),
+  // restoring focus to the last focused agent in the destination tab.
+  const handleCycleTab = useCallback((direction: 'next' | 'prev') => {
+    const tabs = tabManager.customTabs;
+    if (tabs.length < 2) return;
+
+    const currentIdx = tabManager.isCustomTabActive && tabManager.activeCustomTab
+      ? tabs.findIndex(t => t.id === tabManager.activeCustomTab!.id)
+      : 0;
+    const step = direction === 'next' ? 1 : tabs.length - 1;
+    const nextTab = tabs[(currentIdx + step) % tabs.length];
+
+    // Resolve the focus target: last focused agent in the destination tab if
+    // it's still a member, otherwise the first agent. Empty tabs get nothing.
+    const remembered = lastFocusedByTabRef.current.get(nextTab.id);
+    const targetAgentId = remembered && nextTab.agentIds.includes(remembered)
+      ? remembered
+      : nextTab.agentIds[0];
+
+    tabManager.setActiveTab({ type: 'custom', tabId: nextTab.id });
+
+    if (targetAgentId) {
+      setFocusedPanelId(targetAgentId);
+      // Switching tabs re-mounts terminals (registerContainer disposes the old
+      // one and asynchronously inits a new xterm). Stash the focus target —
+      // handleTerminalReady will consume it once the new terminal is ready.
+      pendingFocusRef.current = targetAgentId;
+      // Also try immediately in case the terminal happens to already be live
+      // (no-op if it's not yet registered).
+      multiTerminal.focusTerminal(targetAgentId);
+    }
+  }, [tabManager, multiTerminal]);
+
+  // Keyboard shortcuts (must come after handler declarations to avoid TDZ)
+  const visibleAgentIds = useMemo(
+    () => grid.visiblePanels.map(p => p.agentId),
+    [grid.visiblePanels]
+  );
+
+  useTerminalKeyboard({
+    panelAgentIds: visibleAgentIds,
+    onFocusPanel: handleFocusPanel,
+    onToggleFullscreen: () => grid.toggleFullscreen(focusedPanelId || undefined),
+    onToggleBroadcast: broadcast.toggleBroadcast,
+    onToggleSidebar: () => { },
+    onNewAgent: () => setShowNewChatModal(true),
+    onExitFullscreen: grid.exitFullscreen,
+    onCycleTab: handleCycleTab,
+    isFullscreen: !!grid.fullscreenPanelId,
+  });
 
   const handleStartAll = useCallback(async () => {
     const needsStart = filteredAgents.filter(a =>


### PR DESCRIPTION
## What

Adds two keyboard shortcuts to the terminals dashboard:

| Shortcut | Action |
|----------|--------|
| **Ctrl+Tab** | Switch to the next custom tab (wraps) |
| **Ctrl+Shift+Tab** | Switch to the previous custom tab (wraps) |

After switching, focus is automatically restored to the **last focused agent terminal** in the destination tab — so you can immediately start typing without clicking into the xterm. If no agent has been focused in that tab yet, focus goes to the first agent.

This complements the existing `Ctrl+1-9` shortcut (focus an agent inside the current tab) and gives the dashboard a browser-tab-style navigation flow.

## Why

This was [discussed on Slack with @Charlie85270 ](https://saaspasse.slack.com/archives/C088Q8C3ETF/p1742306400000) — the request was muscle-memory parity with browser tab cycling, plus solving the existing pain point where switching panels required a manual click before typing.

## Implementation notes

- **Per-tab focus memory** is held in a `useRef<Map<tabId, agentId>>` and pruned by a `useEffect` when tabs are deleted (mirrors the cleanup `useTabManager` already does for stale agent IDs and tab layouts).
- **Async focus restoration**: switching tabs re-mounts terminals (`registerContainer` disposes the old xterm and asynchronously inits a new one). A naive synchronous `focusTerminal()` would no-op because the entry isn't in `terminalsRef` yet. So the focus target is stashed in a `pendingFocusRef` and consumed by the existing `onTerminalReady` callback once the new terminal finishes init. A best-effort inline `focusTerminal()` is also called for the case where the destination terminal happens to already be live (fast cycling back to a recent tab).
- **Circular dep**: `handleTerminalReady` is created before `multiTerminal`, so `focusTerminal` is exposed via a `focusTerminalRef` updated post-creation — same pattern `useMultiTerminal.ts` uses internally for `onTerminalReady`.
- **No-op below 2 tabs** — single tab does nothing, no crash.
- **Stale agent guard** — if the remembered agent was removed from the tab, falls back to the first agent.

## Diff scope

- `src/components/TerminalsView/hooks/useTerminalKeyboard.ts` — adds the `onCycleTab` prop + `Ctrl+Tab` handler.
- `src/components/TerminalsView/index.tsx` — adds the refs, the cycle handler, and rewires `useTerminalKeyboard` to use the named `handleFocusPanel` callback (which now also tracks per-tab focus). The `useTerminalKeyboard` call had to move below the handler declarations to avoid TDZ on the new dependency.

No new dependencies, no IPC or Electron main-process changes, no schema changes.

## Test plan

- [ ] Create 2+ custom tabs with at least one agent each
- [ ] Press `Ctrl+Tab` → cycles to next tab, terminal is auto-focused, typing goes straight into the agent
- [ ] Press `Ctrl+Shift+Tab` → cycles backward, wraps from first to last
- [ ] Focus a specific agent in tab A, switch to tab B, switch back → focus restored to that specific agent
- [ ] Delete a tab → no leak in the per-tab focus map
- [ ] Single custom tab → `Ctrl+Tab` is a no-op (no error)
- [ ] Empty custom tab → switch happens, no focus call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to cycle through tabs: press `Ctrl+Tab` to move to the next tab or `Ctrl+Shift+Tab` for the previous tab.
  * Improved tab switching experience with automatic focus restoration to the last active terminal within each tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->