### PR TITLE
feat: remove dashboard tab limit, scroll horizontally instead

### DIFF
--- a/src/components/TerminalsView/components/CustomTabBar.tsx
+++ b/src/components/TerminalsView/components/CustomTabBar.tsx
@@ -7,7 +7,6 @@ import type { CustomTab, ActiveTab } from '../types';
 interface CustomTabBarProps {
   tabs: CustomTab[];
   activeTab: ActiveTab;
-  canCreateTab: boolean;
   onSelectTab: (tabId: string) => void;
   onCreateTab: (name: string) => void;
   onDeleteTab: (tabId: string) => void;
@@ -18,7 +17,6 @@ interface CustomTabBarProps {
 export default function CustomTabBar({
   tabs,
   activeTab,
-  canCreateTab,
   onSelectTab,
   onCreateTab,
   onDeleteTab,
@@ -181,50 +179,48 @@ export default function CustomTabBar({
       ))}
 
       {/* Create tab button + dialog */}
-      {canCreateTab && (
-        <div className="relative shrink-0">
-          <button
-            onClick={() => { setShowCreateDialog(true); setCreateName(''); }}
-            className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-primary/5 transition-colors"
-            title="Create new board (max 5)"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
+      <div className="relative shrink-0">
+        <button
+          onClick={() => { setShowCreateDialog(true); setCreateName(''); }}
+          className="flex items-center gap-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-primary/5 transition-colors"
+          title="Create new board"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
 
-          {showCreateDialog && (
-            <div
-              ref={createDialogRef}
-              className="absolute top-full left-0 mt-1 bg-card border border-border shadow-xl z-50 p-3 min-w-[220px]"
-            >
-              <p className="text-xs text-muted-foreground mb-2">Board name</p>
-              <input
-                ref={createInputRef}
-                value={createName}
-                onChange={e => setCreateName(e.target.value)}
-                onKeyDown={handleCreateKeyDown}
-                placeholder="e.g. Frontend, Backend..."
-                className="w-full px-2 py-1.5 bg-secondary border border-border text-xs text-foreground placeholder:text-muted-foreground outline-none focus:border-white/30 mb-2"
-                maxLength={20}
-              />
-              <div className="flex gap-2 justify-end">
-                <button
-                  onClick={() => { setShowCreateDialog(false); setCreateName(''); }}
-                  className="px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleCreateSubmit}
-                  disabled={!createName.trim()}
-                  className="px-2.5 py-1 text-xs bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-                >
-                  Create
-                </button>
-              </div>
+        {showCreateDialog && (
+          <div
+            ref={createDialogRef}
+            className="absolute top-full left-0 mt-1 bg-card border border-border shadow-xl z-50 p-3 min-w-[220px]"
+          >
+            <p className="text-xs text-muted-foreground mb-2">Board name</p>
+            <input
+              ref={createInputRef}
+              value={createName}
+              onChange={e => setCreateName(e.target.value)}
+              onKeyDown={handleCreateKeyDown}
+              placeholder="e.g. Frontend, Backend..."
+              className="w-full px-2 py-1.5 bg-secondary border border-border text-xs text-foreground placeholder:text-muted-foreground outline-none focus:border-white/30 mb-2"
+              maxLength={20}
+            />
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => { setShowCreateDialog(false); setCreateName(''); }}
+                className="px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreateSubmit}
+                disabled={!createName.trim()}
+                className="px-2.5 py-1 text-xs bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                Create
+              </button>
             </div>
-          )}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/TerminalsView/hooks/useTabManager.ts
+++ b/src/components/TerminalsView/hooks/useTabManager.ts
@@ -6,7 +6,6 @@ import { LAYOUT_PRESETS, getAutoLayout } from '../constants';
 import { deleteTabLayouts } from './useGridLayoutStorage';
 
 const STORAGE_KEY = 'terminals-tab-manager';
-const MAX_TABS = 6;
 
 interface TabManagerState {
   customTabs: CustomTab[];
@@ -87,7 +86,6 @@ export function useTabManager({ existingAgentIds, isLoading }: UseTabManagerOpti
 
   const createTab = useCallback((name: string) => {
     setState(prev => {
-      if (prev.customTabs.length >= MAX_TABS) return prev;
       const newTab: CustomTab = {
         id: crypto.randomUUID(),
         name: name || `Tab ${prev.customTabs.length + 1}`,
@@ -208,7 +206,6 @@ export function useTabManager({ existingAgentIds, isLoading }: UseTabManagerOpti
 
   const isCustomTabActive = state.activeTab.type === 'custom';
   const isProjectTabActive = state.activeTab.type === 'project';
-  const canCreateTab = state.customTabs.length < MAX_TABS;
 
   return {
     customTabs: state.customTabs,
@@ -225,6 +222,5 @@ export function useTabManager({ existingAgentIds, isLoading }: UseTabManagerOpti
     activeProjectPath,
     isCustomTabActive,
     isProjectTabActive,
-    canCreateTab,
   };
 }

--- a/src/components/TerminalsView/index.tsx
+++ b/src/components/TerminalsView/index.tsx
@@ -344,7 +344,6 @@ export default function TerminalsView() {
         <CustomTabBar
           tabs={tabManager.customTabs}
           activeTab={tabManager.activeTab}
-          canCreateTab={tabManager.canCreateTab}
           onSelectTab={(tabId) => tabManager.setActiveTab({ type: 'custom', tabId })}
           onCreateTab={tabManager.createTab}
           onDeleteTab={tabManager.deleteTab}


### PR DESCRIPTION
## Summary
- Drops the 6-tab cap in `useTabManager` (UI tooltip even said "max 5"), so users can create unlimited dashboard boards.
- Removes the `canCreateTab` prop / gated `+` button in `CustomTabBar`; the existing `overflow-x-auto scrollbar-none` container handles horizontal scrolling when tabs overflow.
- No CSS changes needed — tabs already had `whitespace-nowrap shrink-0`, so they scroll cleanly side-to-side without a visible scrollbar.

## Test plan
- [ ] Open the dashboard, create more than 6 named boards in a row — none are blocked.
- [ ] Keep adding boards until the bar overflows the viewport; confirm horizontal scroll works (trackpad / shift+wheel) and no scrollbar is visible.
- [ ] Reload the app and confirm all created boards are restored from `localStorage`.
- [ ] Delete a board and confirm the active-tab fallback still picks the next neighbor.
- [ ] Drag-reorder still works with many tabs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unlimited board creation: The maximum board creation limit has been entirely removed. Users can now create boards without restrictions. Previously, users were limited to a maximum of 5 boards.
  * Enhanced interface: The "Create new board" button has been simplified with clearer labeling, no restriction indicators, and is always available to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->