### PR TITLE
feat: agent templates with built-in roles, import/export, and prompt overrides

### DIFF
--- a/electron/constants/builtin-templates.ts
+++ b/electron/constants/builtin-templates.ts
@@ -1,0 +1,215 @@
+import type { AgentTemplate } from '../types/template';
+
+const FROZEN_TIMESTAMP = '2026-01-01T00:00:00.000Z';
+
+function builtin(t: Omit<AgentTemplate, 'builtin' | 'createdAt' | 'updatedAt'>): AgentTemplate {
+  return {
+    ...t,
+    builtin: true,
+    createdAt: FROZEN_TIMESTAMP,
+    updatedAt: FROZEN_TIMESTAMP,
+  };
+}
+
+export const BUILTIN_TEMPLATES: AgentTemplate[] = [
+  builtin({
+    id: 'builtin:fe-engineer',
+    displayName: 'Frontend Engineer',
+    description: 'Builds and polishes user interfaces. Knows React, design systems, and accessibility.',
+    icon: '🎨',
+    tags: ['frontend', 'engineer'],
+    character: 'ninja',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: [
+      'frontend-design',
+      'web-design-guidelines',
+      'vercel-react-best-practices',
+      'building-native-ui',
+    ],
+    savedPrompt: `Build and modify React, Next.js, and Expo UIs. Ship accessible, typed, performant components that match existing patterns in the codebase.
+
+- Read 2-3 sibling components before writing a new one. Match the project's styling system (Tailwind/CSS Modules/StyleSheet), state library, and file layout exactly. Do not introduce a new dependency without justifying why an existing one fails.
+- Default to Server Components in Next App Router; mark 'use client' only when you need state, effects, refs, or browser APIs. In Expo, prefer platform-agnostic components and gate native-only code with Platform.OS.
+- Type every prop and hook return. No any. Memoize only when a profiler or obvious O(n) render in a list justifies it — premature useMemo/useCallback is noise.
+- Accessibility is not optional: semantic elements, labeled controls, focus management on route/modal changes, keyboard paths for every pointer interaction. Run through tab order mentally before claiming done.
+- After each change, run the project's typecheck and lint (tsc --noEmit, eslint, or the package.json script). Boot the dev server and load the changed route if the harness allows.
+- If the design or data shape is ambiguous and the wrong guess would require a refactor, ask. Otherwise pick the option most consistent with neighboring code and state the assumption in your report.`,
+  }),
+  builtin({
+    id: 'builtin:be-engineer',
+    displayName: 'Backend Engineer',
+    description: 'Designs APIs, data models, and server logic. Cares about reliability and edge cases.',
+    icon: '⚙️',
+    tags: ['backend', 'engineer'],
+    character: 'wizard',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: [
+      'expo-api-routes',
+      'native-data-fetching',
+      'better-auth-best-practices',
+      'mcp-builder',
+    ],
+    savedPrompt: `Build and modify HTTP/RPC APIs, data access, and auth. Optimize for correctness, observability, and a clean contract before cleverness.
+
+- Validate every external input at the boundary with the project's schema lib (zod/pydantic/valibot). Never trust path params, bodies, headers, or env. Return typed errors, not 500s.
+- Treat the database as a contract: write a migration for every schema change, never edit applied migrations, and wrap multi-write operations in transactions. Add the index when you add the query.
+- Authn vs authz are separate checks and both must run on every protected route. Verify the session, then verify the actor owns or has a role for the resource. Log the decision.
+- No secrets in code, logs, or error messages. Read from env/secret manager. Redact tokens, emails, and PII in structured logs.
+- After each change, run unit tests and the integration suite for the touched module. For a new endpoint, add at least one happy-path and one auth-failure test before declaring done.
+- If a requirement implies a breaking API change, stop and propose a versioning path (new route, deprecation header) instead of silently breaking clients. Otherwise proceed and note the contract in your report.`,
+  }),
+  builtin({
+    id: 'builtin:security-engineer',
+    displayName: 'Security Engineer',
+    description: 'Reviews code for vulnerabilities, secrets leaks, and unsafe patterns. Read-only by default.',
+    icon: '🛡️',
+    tags: ['security', 'review'],
+    character: 'knight',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'normal',
+    skills: ['audit-website'],
+    savedPrompt: `Audit code for security defects. Read-only by default — do not edit, refactor, or "fix while you're there". Your output is a findings report, not a patch.
+
+- Walk the threat surface in order: untrusted input sources, authn/authz boundaries, secrets and key handling, deserialization, SSRF/SQLi/XSS/path traversal, dependency CVEs, and CI/CD supply chain.
+- Every finding must include: severity (Critical/High/Medium/Low/Info), CWE or OWASP category, exact path/to/file:line citation, attacker-controlled input trace, and a concrete remediation. No finding without a code citation.
+- Distinguish exploitable from theoretical. If you cannot describe the input that triggers it and the impact, downgrade to Info or drop it. False positives erode trust faster than missed lows.
+- Do not run untrusted scripts, network probes, or anything that touches production. Static review and local test execution only.
+- Do not modify source files, configs, lockfiles, or .env*. If a fix is one line and obvious, describe it in the report — do not apply it.
+- If scope is ambiguous (e.g., "audit the repo" vs "audit this PR"), ask once for the bound, then proceed. Group findings by severity descending in the final report.`,
+  }),
+  builtin({
+    id: 'builtin:code-reviewer',
+    displayName: 'Code Reviewer',
+    description: 'Reviews changes for correctness, style, hidden bugs, and silent failures.',
+    icon: '👁️',
+    tags: ['review', 'quality'],
+    character: 'alien',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'normal',
+    skills: [],
+    savedPrompt: `Review the diff as a senior engineer would. Read-only — do not edit files, run formatters, or commit. Produce line-cited findings the author can act on.
+
+- Read the full diff plus the surrounding context of every changed function before commenting. A change that looks wrong in isolation is often correct given the caller.
+- Every comment cites path/to/file:line (or a line range) and falls into one of: Bug (will fail at runtime), Correctness (logic/edge case), Security, Performance, API/Contract, Test Gap, Style/Naming. Tag each.
+- Lead with blockers. Distinguish "must fix before merge" from "nit/optional". If you have no blockers, say so explicitly — silence reads as disapproval.
+- Verify claims, don't assume: trace types, check error paths, confirm tests actually exercise the new branch. If you can't tell from the diff, say "unable to verify from diff, please confirm X".
+- Do not rewrite the PR. Suggest the smallest change that fixes the issue. Quote the offending line and propose the replacement inline.
+- Do not modify any file. No staging, no commits, no git writes. If the author asks you to apply fixes, hand off — don't switch modes silently.
+- If the PR description is missing context needed to judge intent, ask before reviewing rather than guess wrong.`,
+  }),
+  builtin({
+    id: 'builtin:tester',
+    displayName: 'Tester (QA)',
+    description: 'Writes and runs tests. Hunts edge cases, regressions, and missing coverage.',
+    icon: '🧪',
+    tags: ['testing', 'quality'],
+    character: 'astronaut',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: ['webapp-testing'],
+    savedPrompt: `Write and run tests that catch regressions. Cover behavior, not implementation. Use the framework already configured in the repo (vitest/jest/pytest/playwright) — do not introduce a new one.
+
+- Before writing a test, read existing tests in the same module to match naming, fixture style, and assertion library. Co-locate or mirror the source layout per project convention.
+- For each unit under test, cover: the happy path, one boundary (empty/null/max), one failure mode (thrown error or rejected promise), and any branch the diff added. Skip exhaustive permutations.
+- Prefer real implementations over mocks. Mock only at process boundaries (network, filesystem, clock, randomness). A test that mocks the function it claims to test is worthless.
+- Run the suite after each test you add. Confirm the new test fails against the un-fixed code (for bug tests) and passes against the fix. A green test that never could have failed is a liability.
+- Keep tests deterministic: freeze time, seed randomness, await all promises, no sleep-based waits. Flaky tests must be quarantined or fixed, never retried into green.
+- For E2E, assert on user-visible state (role/text/aria), not CSS selectors or internal IDs.
+- If coverage requirements or a test plan are unspecified, write tests for every changed branch in the diff and report the coverage delta.`,
+  }),
+  builtin({
+    id: 'builtin:refactor',
+    displayName: 'Refactor Specialist',
+    description: 'Simplifies messy code without changing behavior. Splits big files, removes dead code.',
+    icon: '🧹',
+    tags: ['refactor', 'quality'],
+    character: 'robot',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: [],
+    savedPrompt: `Restructure code without changing observable behavior. Every commit must be safe to revert in isolation. The test suite is your contract.
+
+- Before touching anything, run the full test suite and record the baseline (pass count, snapshot hashes, coverage if tracked). If tests are missing for the area you're refactoring, write characterization tests first and commit them separately.
+- Move in small, reversible steps: rename, extract, inline, move file, change signature — one kind of change per commit. Run tests after each step. Never combine a refactor with a behavior change in the same commit.
+- Preserve the public API unless explicitly asked to break it. If a signature must change, update all call sites in the same commit and add a deprecation shim where external consumers may exist.
+- Do not "improve" things outside the stated scope: no reformatting untouched files, no dependency upgrades, no logic "cleanups" that alter edge cases. Drive-by changes hide bugs.
+- Watch for behavior leaks: error messages, log lines, ordering of side effects, timing, and thrown exception types are part of behavior. Diff them.
+- After the final step, re-run the full suite and any integration/E2E tests. Behavior parity means identical outputs, not "looks the same".
+- If a refactor reveals a latent bug, stop and surface it — do not silently fix it inside the refactor.`,
+  }),
+  builtin({
+    id: 'builtin:docs-writer',
+    displayName: 'Docs Writer',
+    description: 'Writes READMEs, changelogs, and inline docs in plain language.',
+    icon: '📝',
+    tags: ['docs', 'writing'],
+    character: 'pirate',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: ['copywriting'],
+    savedPrompt: `Write READMEs, inline comments, API docs, and changelog entries that an engineer joining tomorrow could use. Documentation is code that ships — it must be accurate, current, and tested against reality.
+
+- Verify before you write: read the actual source, run the install/quickstart commands, and confirm every flag, env var, and example output. Never copy from a stale README.
+- Lead every doc with what it does and who it's for in two sentences, then the 30-second quickstart, then reference detail. Burying the install command under philosophy wastes the reader's time.
+- Comments explain why, not what. If the code needs a comment to say what it does, rename it instead. Reserve inline prose for non-obvious tradeoffs, invariants, and links to issues/RFCs.
+- Changelog entries follow Keep a Changelog: group under Added/Changed/Deprecated/Removed/Fixed/Security, write user-facing impact (not commit messages), link the PR.
+- Show, don't tell. Every concept gets a runnable code block. Every code block is copy-pasteable and has been mentally executed.
+- Match the repo's existing voice and Markdown conventions (heading depth, code fence language tags, link style). Do not introduce emojis, badges, or marketing copy unless the project already uses them.
+- If a feature is undocumented and the behavior is ambiguous from the code, ask the author rather than invent semantics.`,
+  }),
+  builtin({
+    id: 'builtin:devops',
+    displayName: 'DevOps Engineer',
+    description: 'Sets up CI, deploy pipelines, and infra glue. Treats production as fragile.',
+    icon: '🚀',
+    tags: ['devops', 'infra'],
+    character: 'viking',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'normal',
+    skills: ['mcp-builder'],
+    savedPrompt: `Own CI/CD pipelines, infrastructure-as-code, container builds, and deploy automation. Optimize for reproducibility, fast feedback, and safe rollback.
+
+- Pin everything: action versions to SHAs, base image digests, package lockfiles, Terraform/Pulumi provider versions. "latest" is not a version.
+- Treat infra changes like prod code: plan/diff before apply, review the plan output, apply through CI not from a laptop. Never run terraform apply or kubectl apply against prod without an approved plan and a rollback path.
+- Secrets live in the secret manager (GitHub Actions secrets, SOPS, Vault, SSM) — never in repo, never in image layers, never in logs. Audit git log -p for accidental leaks before pushing.
+- Make CI fast and trustworthy: cache deps, parallelize independent jobs, fail fast on lint/type before running expensive integration. A 30-minute CI is a broken CI.
+- Every deploy needs a rollback story: previous image tag retained, migrations reversible or expand-contract, feature-flag the risky path. Forward-only is not a strategy.
+- Verify after change: trigger the workflow, watch it green, hit the deployed health endpoint, check logs/metrics for error rate. "Pipeline is green" is not "deploy succeeded".
+- Anything that touches production (apply, deploy, DNS, IAM, data migration) requires explicit user confirmation. When in doubt, propose the plan and wait.`,
+  }),
+  builtin({
+    id: 'builtin:product-designer',
+    displayName: 'Product Designer',
+    description: 'Polishes UX, copy, and visual hierarchy. Pairs well with the Frontend Engineer.',
+    icon: '✨',
+    tags: ['design', 'ux'],
+    character: 'wizard',
+    provider: 'claude',
+    model: 'sonnet',
+    permissionMode: 'auto',
+    skills: ['frontend-design', 'web-design-guidelines', 'copywriting'],
+    savedPrompt: `Polish UX, microcopy, and visual hierarchy in shipped UI code. Work at the component and page level — your output is design improvements implemented in the same stack the app uses.
+
+- Establish hierarchy first: one primary action per view, secondary actions de-emphasized, tertiary hidden in menus. If everything is bold, nothing is. Audit type scale and spacing rhythm before adding new styles.
+- Microcopy is product: buttons name the outcome (Send invite, not Submit), errors tell the user what to do next, empty states teach the feature. Cut hedging words (please, simply, just).
+- Use the design system tokens — spacing, color, radius, typography — that already exist. If you need a new token, add it to the system file, don't inline a magic number.
+- Respect motion and a11y: animations under 250ms, honor prefers-reduced-motion, contrast meets WCAG AA (AAA for body), focus rings visible on all interactives, hit targets at least 44px on touch.
+- Verify on real viewports: 360px mobile, 768px tablet, 1280px desktop. Check dark mode if the app supports it. Tab through the page once before declaring done.
+- Do not redesign architecture, swap component libraries, or rewrite copy outside the requested scope. Small, reversible polish beats a sweeping rework.
+- If brand voice or a design decision is ambiguous, propose two options with tradeoffs rather than picking silently.`,
+  }),
+];
+
+export function getBuiltinTemplate(id: string): AgentTemplate | undefined {
+  return BUILTIN_TEMPLATES.find(t => t.id === id);
+}

--- a/electron/core/agent-manager.ts
+++ b/electron/core/agent-manager.ts
@@ -217,6 +217,11 @@ export function loadAgents() {
         agent.permissionMode = agent.skipPermissions ? 'auto' : 'normal';
       }
 
+      // Backfill createdAt for legacy agents using lastActivity
+      if (!agent.createdAt) {
+        agent.createdAt = agent.lastActivity || new Date().toISOString();
+      }
+
       agents.set(agent.id, agent);
     }
 

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -356,6 +356,7 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
       }
     }
 
+    const now = new Date().toISOString();
     const status: AgentStatus = {
       id,
       status: 'idle',
@@ -365,7 +366,8 @@ function registerAgentHandlers(deps: IpcHandlerDependencies): void {
       branchName,
       skills: config.skills,
       output: [],
-      lastActivity: new Date().toISOString(),
+      lastActivity: now,
+      createdAt: now,
       ptyId,
       character: config.character || 'robot',
       name: config.name || `Agent ${id.slice(0, 4)}`,

--- a/electron/handlers/template-handlers.ts
+++ b/electron/handlers/template-handlers.ts
@@ -1,0 +1,346 @@
+import { ipcMain } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { DATA_DIR } from '../constants';
+import { BUILTIN_TEMPLATES } from '../constants/builtin-templates';
+import type {
+  AgentTemplate,
+  AgentTemplateInput,
+  AgentTemplatePatch,
+  BuiltinOverride,
+  TemplateStore,
+  TemplateExport,
+} from '../types/template';
+import {
+  TEMPLATE_EXPORT_KIND,
+  TEMPLATE_EXPORT_VERSION,
+} from '../types/template';
+
+const TEMPLATES_FILE = path.join(DATA_DIR, 'templates.json');
+const TEMPLATES_BACKUP = path.join(DATA_DIR, 'templates.backup.json');
+
+function ensureDir(): void {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+function emptyStore(): TemplateStore {
+  return { user: [], overrides: {} };
+}
+
+function loadStore(): TemplateStore {
+  ensureDir();
+  if (!fs.existsSync(TEMPLATES_FILE)) return emptyStore();
+  try {
+    const data = fs.readFileSync(TEMPLATES_FILE, 'utf-8');
+    if (!data.trim()) return emptyStore();
+    const parsed = JSON.parse(data);
+
+    // Legacy format: bare array of user templates
+    if (Array.isArray(parsed)) {
+      return {
+        user: parsed.filter((t): t is AgentTemplate => !!t && !t.builtin),
+        overrides: {},
+      };
+    }
+
+    // Current format
+    return {
+      user: Array.isArray(parsed.user) ? parsed.user.filter((t: AgentTemplate) => !t.builtin) : [],
+      overrides: typeof parsed.overrides === 'object' && parsed.overrides ? parsed.overrides : {},
+    };
+  } catch (err) {
+    console.error('Failed to load templates.json:', err);
+    return emptyStore();
+  }
+}
+
+function saveStore(store: TemplateStore): void {
+  ensureDir();
+  if (fs.existsSync(TEMPLATES_FILE)) {
+    const existing = fs.readFileSync(TEMPLATES_FILE, 'utf-8');
+    if (existing.trim().length > 2) {
+      fs.writeFileSync(TEMPLATES_BACKUP, existing);
+    }
+  }
+  fs.writeFileSync(TEMPLATES_FILE, JSON.stringify(store, null, 2));
+}
+
+function applyOverride(builtin: AgentTemplate, override: BuiltinOverride | undefined): AgentTemplate {
+  if (!override) return { ...builtin, overridden: false };
+  return {
+    ...builtin,
+    ...override,
+    id: builtin.id,
+    builtin: true,
+    overridden: true,
+    createdAt: builtin.createdAt,
+    updatedAt: override.updatedAt,
+  };
+}
+
+function buildFromInput(input: AgentTemplateInput): AgentTemplate {
+  const now = new Date().toISOString();
+  return {
+    id: uuidv4(),
+    builtin: false,
+    displayName: input.displayName,
+    description: input.description ?? '',
+    icon: input.icon ?? '🤖',
+    tags: input.tags ?? [],
+    character: input.character ?? 'robot',
+    provider: input.provider ?? 'claude',
+    model: input.model,
+    localModel: input.localModel,
+    permissionMode: input.permissionMode ?? 'normal',
+    effort: input.effort,
+    skills: input.skills ?? [],
+    obsidianVaultPaths: input.obsidianVaultPaths,
+    savedPrompt: input.savedPrompt,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function overrideFromPatch(patch: AgentTemplatePatch, prev?: BuiltinOverride): BuiltinOverride {
+  const merged: BuiltinOverride = {
+    ...prev,
+    updatedAt: new Date().toISOString(),
+  };
+  // Only assign fields that were actually provided in the patch
+  if (patch.displayName !== undefined) merged.displayName = patch.displayName;
+  if (patch.description !== undefined) merged.description = patch.description;
+  if (patch.icon !== undefined) merged.icon = patch.icon;
+  if (patch.tags !== undefined) merged.tags = patch.tags;
+  if (patch.character !== undefined) merged.character = patch.character;
+  if (patch.provider !== undefined) merged.provider = patch.provider;
+  if (patch.model !== undefined) merged.model = patch.model;
+  if (patch.localModel !== undefined) merged.localModel = patch.localModel;
+  if (patch.permissionMode !== undefined) merged.permissionMode = patch.permissionMode;
+  if (patch.effort !== undefined) merged.effort = patch.effort;
+  if (patch.skills !== undefined) merged.skills = patch.skills;
+  if (patch.obsidianVaultPaths !== undefined) merged.obsidianVaultPaths = patch.obsidianVaultPaths;
+  if (patch.savedPrompt !== undefined) merged.savedPrompt = patch.savedPrompt;
+  return merged;
+}
+
+export function registerTemplateHandlers(): void {
+  ipcMain.handle('template:list', async () => {
+    try {
+      const store = loadStore();
+      const builtinsMerged = BUILTIN_TEMPLATES.map(b => applyOverride(b, store.overrides[b.id]));
+      return { templates: [...builtinsMerged, ...store.user] };
+    } catch (err) {
+      console.error('template:list error:', err);
+      return {
+        templates: BUILTIN_TEMPLATES.map(b => ({ ...b, overridden: false })),
+        error: err instanceof Error ? err.message : 'Failed to list templates',
+      };
+    }
+  });
+
+  ipcMain.handle('template:get', async (_event, id: string) => {
+    const store = loadStore();
+    const builtin = BUILTIN_TEMPLATES.find(t => t.id === id);
+    if (builtin) {
+      return { template: applyOverride(builtin, store.overrides[id]) };
+    }
+    const userTemplate = store.user.find(t => t.id === id);
+    return { template: userTemplate ?? null };
+  });
+
+  ipcMain.handle('template:create', async (_event, input: AgentTemplateInput) => {
+    try {
+      if (!input?.displayName?.trim()) {
+        return { success: false, error: 'displayName is required' };
+      }
+      const template = buildFromInput(input);
+      const store = loadStore();
+      store.user.push(template);
+      saveStore(store);
+      return { success: true, template };
+    } catch (err) {
+      console.error('template:create error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to create template' };
+    }
+  });
+
+  ipcMain.handle('template:update', async (_event, patch: AgentTemplatePatch) => {
+    try {
+      const store = loadStore();
+      const builtin = BUILTIN_TEMPLATES.find(t => t.id === patch.id);
+
+      if (builtin) {
+        // Edits on built-ins are stored as overrides; the built-in keeps its slot.
+        const nextOverride = overrideFromPatch(patch, store.overrides[patch.id]);
+        store.overrides[patch.id] = nextOverride;
+        saveStore(store);
+        return { success: true, template: applyOverride(builtin, nextOverride) };
+      }
+
+      const idx = store.user.findIndex(t => t.id === patch.id);
+      if (idx === -1) return { success: false, error: 'Template not found' };
+
+      const merged: AgentTemplate = {
+        ...store.user[idx],
+        ...patch,
+        id: store.user[idx].id,
+        builtin: false,
+        createdAt: store.user[idx].createdAt,
+        updatedAt: new Date().toISOString(),
+      };
+      store.user[idx] = merged;
+      saveStore(store);
+      return { success: true, template: merged };
+    } catch (err) {
+      console.error('template:update error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to update template' };
+    }
+  });
+
+  ipcMain.handle('template:delete', async (_event, id: string) => {
+    try {
+      const store = loadStore();
+      const isBuiltin = BUILTIN_TEMPLATES.some(t => t.id === id);
+
+      if (isBuiltin) {
+        // Built-ins can't be removed; deleting "resets" the override if any.
+        if (!store.overrides[id]) {
+          return { success: false, error: 'Built-in templates cannot be deleted.' };
+        }
+        delete store.overrides[id];
+        saveStore(store);
+        return { success: true, reset: true };
+      }
+
+      const next = store.user.filter(t => t.id !== id);
+      if (next.length === store.user.length) {
+        return { success: false, error: 'Template not found' };
+      }
+      store.user = next;
+      saveStore(store);
+      return { success: true };
+    } catch (err) {
+      console.error('template:delete error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to delete template' };
+    }
+  });
+
+  ipcMain.handle('template:export', async (_event, ids: string[]) => {
+    try {
+      const store = loadStore();
+      const all: AgentTemplate[] = [
+        ...BUILTIN_TEMPLATES.map(b => applyOverride(b, store.overrides[b.id])),
+        ...store.user,
+      ];
+      const wanted = ids.length > 0 ? all.filter(t => ids.includes(t.id)) : all;
+      if (wanted.length === 0) {
+        return { success: false, error: 'No matching templates to export' };
+      }
+      const payload: TemplateExport = {
+        version: TEMPLATE_EXPORT_VERSION,
+        kind: TEMPLATE_EXPORT_KIND,
+        exportedAt: new Date().toISOString(),
+        templates: wanted.map(t => ({
+          displayName: t.displayName,
+          description: t.description,
+          icon: t.icon,
+          tags: t.tags,
+          character: t.character,
+          provider: t.provider,
+          model: t.model,
+          localModel: t.localModel,
+          permissionMode: t.permissionMode,
+          effort: t.effort,
+          skills: t.skills,
+          obsidianVaultPaths: t.obsidianVaultPaths,
+          savedPrompt: t.savedPrompt,
+        })),
+      };
+      return { success: true, payload };
+    } catch (err) {
+      console.error('template:export error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to export templates' };
+    }
+  });
+
+  ipcMain.handle('template:import', async (_event, payload: unknown) => {
+    try {
+      if (!payload || typeof payload !== 'object') {
+        return { success: false, error: 'Invalid file: not an object' };
+      }
+      const p = payload as Partial<TemplateExport>;
+      if (p.kind !== TEMPLATE_EXPORT_KIND) {
+        return { success: false, error: 'Not a Dorothy template file' };
+      }
+      if (p.version !== TEMPLATE_EXPORT_VERSION) {
+        return { success: false, error: `Unsupported template version: ${String(p.version)}` };
+      }
+      if (!Array.isArray(p.templates) || p.templates.length === 0) {
+        return { success: false, error: 'No templates found in file' };
+      }
+
+      const store = loadStore();
+      const created: AgentTemplate[] = [];
+      const errors: string[] = [];
+
+      for (const raw of p.templates) {
+        if (!raw || typeof raw !== 'object' || typeof raw.displayName !== 'string' || !raw.displayName.trim()) {
+          errors.push('Skipped a template missing displayName');
+          continue;
+        }
+        const template = buildFromInput(raw);
+        store.user.push(template);
+        created.push(template);
+      }
+
+      if (created.length > 0) saveStore(store);
+
+      return {
+        success: created.length > 0,
+        imported: created.length,
+        skipped: errors.length,
+        errors,
+        templates: created,
+      };
+    } catch (err) {
+      console.error('template:import error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to import templates' };
+    }
+  });
+
+  ipcMain.handle('template:duplicate', async (_event, id: string) => {
+    try {
+      const store = loadStore();
+      const builtin = BUILTIN_TEMPLATES.find(t => t.id === id);
+      const source = builtin
+        ? applyOverride(builtin, store.overrides[id])
+        : store.user.find(t => t.id === id);
+      if (!source) return { success: false, error: 'Template not found' };
+
+      const copy = buildFromInput({
+        displayName: `${source.displayName} (copy)`,
+        description: source.description,
+        icon: source.icon,
+        tags: source.tags,
+        character: source.character,
+        provider: source.provider,
+        model: source.model,
+        localModel: source.localModel,
+        permissionMode: source.permissionMode,
+        effort: source.effort,
+        skills: source.skills,
+        obsidianVaultPaths: source.obsidianVaultPaths,
+        savedPrompt: source.savedPrompt,
+      });
+      store.user.push(copy);
+      saveStore(store);
+      return { success: true, template: copy };
+    } catch (err) {
+      console.error('template:duplicate error:', err);
+      return { success: false, error: err instanceof Error ? err.message : 'Failed to duplicate template' };
+    }
+  });
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -91,6 +91,7 @@ import { registerCLIPathsHandlers } from './handlers/cli-paths-handlers';
 import { registerKanbanHandlers } from './handlers/kanban-handlers';
 import { registerVaultHandlers } from './handlers/vault-handlers';
 import { registerWorldHandlers } from './handlers/world-handlers';
+import { registerTemplateHandlers } from './handlers/template-handlers';
 import { initVaultDb, closeVaultDb } from './services/vault-db';
 import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
 import { initKanbanAutomation, findMatchingAgent, createAgentForTask, startAgentForTask } from './services/kanban-automation';
@@ -357,6 +358,9 @@ app.whenReady().then(async () => {
     setAppSettings: (settings) => { appSettings = settings; },
     saveAppSettings: saveAppSettingsToFile,
   });
+
+  // Register agent template handlers (no deps — self-contained)
+  registerTemplateHandlers();
 
   // Register kanban handlers
   registerKanbanHandlers({

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -482,6 +482,26 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
   },
 
+  // Agent templates
+  template: {
+    list: () =>
+      ipcRenderer.invoke('template:list'),
+    get: (id: string) =>
+      ipcRenderer.invoke('template:get', id),
+    create: (input: Record<string, unknown>) =>
+      ipcRenderer.invoke('template:create', input),
+    update: (patch: Record<string, unknown>) =>
+      ipcRenderer.invoke('template:update', patch),
+    delete: (id: string) =>
+      ipcRenderer.invoke('template:delete', id),
+    duplicate: (id: string) =>
+      ipcRenderer.invoke('template:duplicate', id),
+    export: (ids: string[]) =>
+      ipcRenderer.invoke('template:export', ids),
+    import: (payload: unknown) =>
+      ipcRenderer.invoke('template:import', payload),
+  },
+
   // Vault
   vault: {
     listDocuments: (params?: { folder_id?: string; tags?: string[] }) =>

--- a/electron/types/index.ts
+++ b/electron/types/index.ts
@@ -50,6 +50,7 @@ export interface AgentStatus {
   localModel?: string;        // Tasmania model name when provider is 'local'
   savedPrompt?: string;       // Saved task/prompt for re-launching the agent
   obsidianVaultPaths?: string[]; // Obsidian vault paths to mount via --add-dir (read-only)
+  createdAt?: string;         // ISO timestamp when the agent was created
 }
 
 export interface CLIPaths {

--- a/electron/types/template.ts
+++ b/electron/types/template.ts
@@ -1,0 +1,90 @@
+import type { AgentCharacter, AgentProvider, AgentPermissionMode, AgentEffort } from './index';
+
+export interface AgentTemplate {
+  id: string;
+  builtin: boolean;
+  /** True if this built-in has been customized by the user. Always false for user templates. */
+  overridden?: boolean;
+  displayName: string;
+  description: string;
+  icon: string;
+  tags: string[];
+  character: AgentCharacter;
+  provider: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode: AgentPermissionMode;
+  effort?: AgentEffort;
+  skills: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** User overrides on a built-in template. The built-in's id is the key in the store. */
+export interface BuiltinOverride {
+  displayName?: string;
+  description?: string;
+  icon?: string;
+  tags?: string[];
+  character?: AgentCharacter;
+  provider?: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode?: AgentPermissionMode;
+  effort?: AgentEffort;
+  skills?: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+  updatedAt: string;
+}
+
+export interface TemplateStore {
+  user: AgentTemplate[];
+  overrides: Record<string, BuiltinOverride>;
+}
+
+export const TEMPLATE_EXPORT_KIND = 'dorothy.agent-template' as const;
+export const TEMPLATE_EXPORT_VERSION = 1 as const;
+
+/** Wire format for sharing templates between Dorothy installs. */
+export interface TemplateExport {
+  version: typeof TEMPLATE_EXPORT_VERSION;
+  kind: typeof TEMPLATE_EXPORT_KIND;
+  exportedAt: string;
+  templates: AgentTemplateInput[];
+}
+
+export interface AgentTemplateInput {
+  displayName: string;
+  description?: string;
+  icon?: string;
+  tags?: string[];
+  character?: AgentCharacter;
+  provider?: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode?: AgentPermissionMode;
+  effort?: AgentEffort;
+  skills?: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+}
+
+export interface AgentTemplatePatch {
+  id: string;
+  displayName?: string;
+  description?: string;
+  icon?: string;
+  tags?: string[];
+  character?: AgentCharacter;
+  provider?: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode?: AgentPermissionMode;
+  effort?: AgentEffort;
+  skills?: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+}

--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from 'react';
 import { Bot, Loader2, Search, ArrowUpDown } from 'lucide-react';
 import { useElectronAgents, useElectronFS, useElectronSkills, isElectron } from '@/hooks/useElectron';
+import { useElectronTemplates } from '@/hooks/useElectronTemplates';
 import { useClaude } from '@/hooks/useClaude';
 import { useAgentFiltering } from '@/hooks/useAgentFiltering';
 import { useSuperAgent } from '@/hooks/useSuperAgent';
@@ -18,7 +19,7 @@ import {
 } from '@/components/AgentList';
 import { STATUS_LABELS, STATUS_COLORS } from './constants';
 
-type SortBy = 'status' | 'activity' | 'name';
+type SortBy = 'created' | 'status' | 'activity' | 'name';
 
 export default function AgentsPage() {
   const {
@@ -33,6 +34,7 @@ export default function AgentsPage() {
   } = useElectronAgents();
   const { projects, openFolderDialog } = useElectronFS();
   const { installedSkills, refresh: refreshSkills } = useElectronSkills();
+  const { create: createTemplate } = useElectronTemplates();
   const { data: claudeData } = useClaude();
 
   // Local state
@@ -43,7 +45,7 @@ export default function AgentsPage() {
   const [projectFilter, setProjectFilter] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [sortBy, setSortBy] = useState<SortBy>('status');
+  const [sortBy, setSortBy] = useState<SortBy>('created');
 
 
   // Custom hooks
@@ -146,15 +148,41 @@ export default function AgentsPage() {
     removeAgent(agentId);
   }, [removeAgent]);
 
+  const handleSaveAsTemplate = useCallback(async (agentId: string) => {
+    const agent = agents.find(a => a.id === agentId);
+    if (!agent) return;
+    const suggested = agent.name?.trim() || `Agent ${agent.id.slice(0, 4)}`;
+    const name = window.prompt('Save as template — name?', suggested);
+    if (!name?.trim()) return;
+    const result = await createTemplate({
+      displayName: name.trim(),
+      description: `Saved from agent "${agent.name ?? ''}"`.trim(),
+      icon: '📦',
+      character: agent.character,
+      provider: agent.provider,
+      model: agent.model,
+      localModel: agent.localModel,
+      permissionMode: agent.permissionMode ?? (agent.skipPermissions ? 'auto' : 'normal'),
+      effort: agent.effort,
+      skills: agent.skills,
+      obsidianVaultPaths: agent.obsidianVaultPaths,
+      savedPrompt: agent.savedPrompt,
+    });
+    if (!result.success) {
+      alert(`Could not save template: ${result.error ?? 'unknown error'}`);
+    }
+  }, [agents, createTemplate]);
+
   const agentCountByProject = useCallback((path: string) => {
     return agents.filter(a => a.projectPath === path).length;
   }, [agents]);
 
   const cycleSortBy = useCallback(() => {
     setSortBy(prev => {
+      if (prev === 'created') return 'status';
       if (prev === 'status') return 'activity';
       if (prev === 'activity') return 'name';
-      return 'status';
+      return 'created';
     });
   }, []);
 
@@ -270,6 +298,7 @@ export default function AgentsPage() {
                 onStart={() => handleStartAgent(agent.id)}
                 onStop={() => stopAgent(agent.id)}
                 onRemove={() => handleRemoveAgent(agent.id)}
+                onSaveAsTemplate={() => handleSaveAsTemplate(agent.id)}
               />
             ))}
           </div>

--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -1,0 +1,256 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Loader2, Plus, Sparkles, Upload } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { isElectron, useElectronSkills } from '@/hooks/useElectron';
+import { useElectronTemplates } from '@/hooks/useElectronTemplates';
+import type { AgentTemplate, AgentTemplateInput } from '@/types/electron';
+import { DesktopRequiredMessage } from '@/components/AgentList';
+import { TemplateCard } from '@/components/Templates/TemplateCard';
+import { InstantiateDialog } from '@/components/Templates/InstantiateDialog';
+import { TemplateFormDialog } from '@/components/Templates/TemplateFormDialog';
+import { ImportDialog } from '@/components/Templates/ImportDialog';
+import TerminalDialog from '@/components/TerminalDialog';
+import { SKILLS_DATABASE, fetchSkillsFromMarketplace, type Skill } from '@/lib/skills-database';
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const hasElectron = isElectron();
+  const { builtinTemplates, userTemplates, isLoading, create, update, remove, duplicate, exportTemplates, importTemplates } = useElectronTemplates();
+  const { installedSkills, refresh: refreshSkills } = useElectronSkills();
+
+  const [instantiateTarget, setInstantiateTarget] = useState<AgentTemplate | null>(null);
+  const [editTarget, setEditTarget] = useState<AgentTemplate | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [showImport, setShowImport] = useState(false);
+
+  const [liveSkills, setLiveSkills] = useState<Skill[] | null>(null);
+  const [installSkillTarget, setInstallSkillTarget] = useState<{ repo: string; title: string } | null>(null);
+  const [installError, setInstallError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchSkillsFromMarketplace().then(s => { if (s) setLiveSkills(s); }).catch(() => {});
+  }, []);
+
+  function findSkillRepo(skillName: string): string | null {
+    const candidates = liveSkills ?? SKILLS_DATABASE;
+    const lower = skillName.toLowerCase();
+    const match = candidates.find(s => s.name.toLowerCase() === lower);
+    return match ? match.repo : null;
+  }
+
+  function handleInstallSkill(skillName: string) {
+    const repo = findSkillRepo(skillName);
+    if (!repo) {
+      setInstallError(`"${skillName}" isn't in the public marketplace. Install it manually from the Skills page.`);
+      return;
+    }
+    setInstallSkillTarget({ repo: `${repo}/${skillName}`, title: skillName });
+  }
+
+  if (!hasElectron) {
+    return (
+      <div className="p-6">
+        <DesktopRequiredMessage />
+      </div>
+    );
+  }
+
+  async function handleCreate(input: AgentTemplateInput) {
+    const result = await create(input);
+    return { success: result.success, error: result.error };
+  }
+
+  async function handleUpdate(input: AgentTemplateInput) {
+    if (!editTarget) return { success: false, error: 'No template selected' };
+    const result = await update({ id: editTarget.id, ...input });
+    return { success: result.success, error: result.error };
+  }
+
+  async function handleDelete(template: AgentTemplate) {
+    if (!confirm(`Delete template "${template.displayName}"? This cannot be undone.`)) return;
+    await remove(template.id);
+  }
+
+  async function handleReset(template: AgentTemplate) {
+    if (!confirm(`Reset "${template.displayName}" to its default settings?`)) return;
+    await remove(template.id);
+  }
+
+  async function handleDuplicate(template: AgentTemplate) {
+    await duplicate(template.id);
+  }
+
+  async function handleExport(template: AgentTemplate) {
+    const result = await exportTemplates([template.id]);
+    if (!result.success || !result.payload) return;
+    const filename = `${template.displayName.toLowerCase().replace(/[^a-z0-9-]+/g, '-').replace(/^-+|-+$/g, '') || 'template'}.dorothy-template.json`;
+    const blob = new Blob([JSON.stringify(result.payload, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <div className="flex items-center justify-between gap-3 mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-foreground flex items-center gap-2">
+            <Sparkles className="w-6 h-6 text-primary" />
+            Agent Templates
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Pick a role, point it at a project, get an agent. No setup required.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowImport(true)}
+            className="flex items-center gap-1.5 px-3 py-2 border border-border bg-card text-xs font-medium text-foreground hover:bg-accent/50 transition-colors"
+          >
+            <Upload className="w-4 h-4" />
+            Import
+          </button>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-1.5 px-3 py-2 bg-foreground text-background text-xs font-medium hover:bg-foreground/90 transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            New blank template
+          </button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-20 text-muted-foreground">
+          <Loader2 className="w-5 h-5 animate-spin mr-2" />
+          Loading templates…
+        </div>
+      ) : (
+        <>
+          <section className="mb-8">
+            <h2 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">
+              Built-in roles
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {builtinTemplates.map(t => (
+                <TemplateCard
+                  key={t.id}
+                  template={t}
+                  installedSkills={installedSkills}
+                  onUse={() => setInstantiateTarget(t)}
+                  onEdit={() => setEditTarget(t)}
+                  onDuplicate={() => handleDuplicate(t)}
+                  onReset={t.overridden ? () => handleReset(t) : undefined}
+                  onExport={() => handleExport(t)}
+                  onInstallSkill={handleInstallSkill}
+                />
+              ))}
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">
+              Your templates
+            </h2>
+            {userTemplates.length === 0 ? (
+              <div className="border border-dashed border-border bg-secondary/20 p-8 text-center">
+                <p className="text-sm text-muted-foreground mb-3">
+                  You haven&apos;t saved any templates yet.
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Duplicate a built-in role to customize it, or create a blank template.
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                {userTemplates.map(t => (
+                  <TemplateCard
+                    key={t.id}
+                    template={t}
+                    installedSkills={installedSkills}
+                    onUse={() => setInstantiateTarget(t)}
+                    onEdit={() => setEditTarget(t)}
+                    onDuplicate={() => handleDuplicate(t)}
+                    onDelete={() => handleDelete(t)}
+                    onExport={() => handleExport(t)}
+                    onInstallSkill={handleInstallSkill}
+                  />
+                ))}
+              </div>
+            )}
+          </section>
+        </>
+      )}
+
+      {instantiateTarget && (
+        <InstantiateDialog
+          template={instantiateTarget}
+          onClose={() => setInstantiateTarget(null)}
+          onCreated={() => router.push('/agents')}
+        />
+      )}
+
+      {showCreate && (
+        <TemplateFormDialog
+          installedSkills={installedSkills}
+          onClose={() => setShowCreate(false)}
+          onSubmit={handleCreate}
+        />
+      )}
+
+      {editTarget && (
+        <TemplateFormDialog
+          initialTemplate={editTarget}
+          installedSkills={installedSkills}
+          onClose={() => setEditTarget(null)}
+          onSubmit={handleUpdate}
+        />
+      )}
+
+      {showImport && (
+        <ImportDialog
+          onClose={() => setShowImport(false)}
+          onImport={importTemplates}
+        />
+      )}
+
+      <TerminalDialog
+        open={!!installSkillTarget}
+        repo={installSkillTarget?.repo ?? ''}
+        title={installSkillTarget?.title ?? ''}
+        availableProviders={['claude', 'codex', 'gemini']}
+        onClose={() => {
+          setInstallSkillTarget(null);
+          refreshSkills();
+        }}
+      />
+
+      {installError && (
+        <div className="fixed bottom-4 right-4 z-50 max-w-sm bg-card border border-amber-500/40 px-4 py-3 shadow-lg flex flex-col gap-2">
+          <p className="text-xs text-foreground">{installError}</p>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              onClick={() => setInstallError(null)}
+              className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+            >
+              Dismiss
+            </button>
+            <button
+              onClick={() => { setInstallError(null); router.push('/skills'); }}
+              className="text-xs bg-foreground text-background font-medium px-2 py-1 hover:bg-foreground/90"
+            >
+              Open Skills page
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AgentList/AgentManagementCard.tsx
+++ b/src/components/AgentList/AgentManagementCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Play, Square, Pencil, Trash2, AlertTriangle, Crown, Clock } from 'lucide-react';
+import { Play, Square, Pencil, Trash2, AlertTriangle, Crown, Clock, BookmarkPlus } from 'lucide-react';
 import type { AgentStatus } from '@/types/electron';
 import {
   STATUS_COLORS,
@@ -27,9 +27,10 @@ interface AgentManagementCardProps {
   onStart: () => void;
   onStop: () => void;
   onRemove: () => void;
+  onSaveAsTemplate?: () => void;
 }
 
-export function AgentManagementCard({ agent, onClick, onEdit, onStart, onStop, onRemove }: AgentManagementCardProps) {
+export function AgentManagementCard({ agent, onClick, onEdit, onStart, onStop, onRemove, onSaveAsTemplate }: AgentManagementCardProps) {
   const statusConfig = STATUS_COLORS[agent.status];
   const isSuper = isSuperAgentCheck(agent);
   const isRunning = agent.status === 'running' || agent.status === 'waiting';
@@ -144,6 +145,15 @@ export function AgentManagementCard({ agent, onClick, onEdit, onStart, onStop, o
           >
             <Pencil className="w-3.5 h-3.5 text-muted-foreground" />
           </button>
+          {onSaveAsTemplate && (
+            <button
+              onClick={onSaveAsTemplate}
+              className="p-1.5 hover:bg-primary/10 rounded transition-colors"
+              title="Save as template"
+            >
+              <BookmarkPlus className="w-3.5 h-3.5 text-muted-foreground hover:text-primary" />
+            </button>
+          )}
           <button
             onClick={onRemove}
             className="p-1.5 hover:bg-red-500/10 rounded transition-colors"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ import { usePathname } from 'next/navigation';
 const navItems = [
   { href: '/', icon: LayoutDashboard, label: 'Dashboard', shortcut: '1' },
   { href: '/agents', icon: Bot, label: 'Agents', shortcut: '2' },
+  { href: '/templates', icon: Sparkles, label: 'Templates', shortcut: 'T' },
   { href: '/kanban', icon: Columns, label: 'Kanban', shortcut: '3' },
   { href: '/vault', icon: Archive, label: 'Vault', shortcut: '4' },
   { href: '/projects', icon: FolderKanban, label: 'Projects', shortcut: '5' },

--- a/src/components/Templates/ImportDialog.tsx
+++ b/src/components/Templates/ImportDialog.tsx
@@ -90,13 +90,18 @@ export function ImportDialog({ onClose, onImport }: ImportDialogProps) {
     if (!parsed) return;
     setSubmitting(true);
     setSubmitError(null);
-    const result = await onImport(parsed);
-    setSubmitting(false);
-    if (!result.success) {
-      setSubmitError(result.error ?? 'Import failed');
-      return;
+    try {
+      const result = await onImport(parsed);
+      if (!result.success) {
+        setSubmitError(result.error ?? 'Import failed');
+        return;
+      }
+      onClose();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Import failed');
+    } finally {
+      setSubmitting(false);
     }
-    onClose();
   }
 
   return (

--- a/src/components/Templates/ImportDialog.tsx
+++ b/src/components/Templates/ImportDialog.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { FileText, Loader2, Upload, X } from 'lucide-react';
+
+interface ImportDialogProps {
+  onClose: () => void;
+  onImport: (payload: unknown) => Promise<{ success: boolean; imported?: number; skipped?: number; errors?: string[]; error?: string }>;
+}
+
+interface ParsedPreview {
+  count: number;
+  names: string[];
+}
+
+export function ImportDialog({ onClose, onImport }: ImportDialogProps) {
+  const [text, setText] = useState('');
+  const [parsed, setParsed] = useState<unknown>(null);
+  const [preview, setPreview] = useState<ParsedPreview | null>(null);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    const onClick = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onClick);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onClick);
+    };
+  }, [onClose]);
+
+  function tryParse(value: string) {
+    setText(value);
+    setParseError(null);
+    setSubmitError(null);
+    if (!value.trim()) {
+      setParsed(null);
+      setPreview(null);
+      return;
+    }
+    try {
+      const json = JSON.parse(value);
+      if (!json || typeof json !== 'object') {
+        setParseError('JSON must be an object');
+        setParsed(null);
+        setPreview(null);
+        return;
+      }
+      if (json.kind !== 'dorothy.agent-template') {
+        setParseError('Not a Dorothy template file (missing kind: "dorothy.agent-template")');
+        setParsed(null);
+        setPreview(null);
+        return;
+      }
+      if (!Array.isArray(json.templates)) {
+        setParseError('Missing or invalid "templates" array');
+        setParsed(null);
+        setPreview(null);
+        return;
+      }
+      const items = json.templates as unknown[];
+      const names = items
+        .filter((t): t is { displayName: string } =>
+          !!t && typeof t === 'object' && typeof (t as { displayName?: unknown }).displayName === 'string'
+        )
+        .map(t => t.displayName);
+      setParsed(json);
+      setPreview({ count: names.length, names });
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : 'Invalid JSON');
+      setParsed(null);
+      setPreview(null);
+    }
+  }
+
+  async function handleFile(file: File) {
+    const content = await file.text();
+    tryParse(content);
+  }
+
+  async function handleSubmit() {
+    if (!parsed) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    const result = await onImport(parsed);
+    setSubmitting(false);
+    if (!result.success) {
+      setSubmitError(result.error ?? 'Import failed');
+      return;
+    }
+    onClose();
+  }
+
+  return (
+    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div ref={dialogRef} className="bg-card border border-border w-full max-w-xl max-h-[90vh] flex flex-col">
+        <div className="px-5 py-4 border-b border-border flex items-center justify-between gap-3">
+          <h2 className="font-semibold text-foreground">Import templates</h2>
+          <button onClick={onClose} className="p-1 text-muted-foreground hover:text-foreground" title="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-3">
+          <p className="text-xs text-muted-foreground">
+            Paste a Dorothy template JSON below or upload a <code className="text-foreground bg-secondary px-1">.json</code> file. Imported templates land under <strong>Your templates</strong>.
+          </p>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs bg-secondary border border-border hover:bg-accent/50 transition-colors"
+            >
+              <Upload className="w-3 h-3" />
+              Upload file
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="application/json,.json"
+              className="hidden"
+              onChange={e => {
+                const f = e.target.files?.[0];
+                if (f) handleFile(f);
+                e.target.value = '';
+              }}
+            />
+          </div>
+
+          <textarea
+            value={text}
+            onChange={e => tryParse(e.target.value)}
+            placeholder='{ "kind": "dorothy.agent-template", "version": 1, "templates": [...] }'
+            rows={10}
+            className="w-full px-2 py-1.5 bg-secondary border border-border text-xs text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40 font-mono resize-y"
+          />
+
+          {parseError && (
+            <p className="text-xs text-amber-700 dark:text-amber-400 bg-amber-500/10 border border-amber-500/30 px-2 py-1.5">{parseError}</p>
+          )}
+
+          {preview && (
+            <div className="border border-border bg-secondary/30 px-3 py-2">
+              <p className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                <FileText className="w-3 h-3" />
+                {preview.count} template{preview.count === 1 ? '' : 's'} ready to import
+              </p>
+              <ul className="text-xs text-muted-foreground list-disc pl-5 space-y-0.5">
+                {preview.names.slice(0, 8).map((n, i) => <li key={`${n}-${i}`}>{n}</li>)}
+                {preview.names.length > 8 && <li>…and {preview.names.length - 8} more</li>}
+              </ul>
+            </div>
+          )}
+
+          {submitError && (
+            <p className="text-xs text-destructive bg-destructive/10 border border-destructive/30 px-2 py-1.5">{submitError}</p>
+          )}
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!parsed || submitting}
+            className="px-3 py-1.5 text-xs bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+            Import
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Templates/InstantiateDialog.tsx
+++ b/src/components/Templates/InstantiateDialog.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FolderOpen, Loader2, Search, X } from 'lucide-react';
+import type { AgentTemplate } from '@/types/electron';
+import { useElectronAgents, useElectronFS } from '@/hooks/useElectron';
+
+interface InstantiateDialogProps {
+  template: AgentTemplate;
+  onClose: () => void;
+  onCreated?: (agentId: string) => void;
+}
+
+export function InstantiateDialog({ template, onClose, onCreated }: InstantiateDialogProps) {
+  const { createAgent, startAgent } = useElectronAgents();
+  const { projects, openFolderDialog } = useElectronFS();
+
+  const [projectPath, setProjectPath] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  const [name, setName] = useState(template.displayName);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Click outside / Escape to close
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    const onClick = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onClick);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onClick);
+    };
+  }, [onClose]);
+
+  const filteredProjects = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return projects;
+    return projects.filter(p => p.name.toLowerCase().includes(q) || p.path.toLowerCase().includes(q));
+  }, [projects, search]);
+
+  async function handlePickFolder() {
+    try {
+      const picked = await openFolderDialog();
+      if (typeof picked === 'string' && picked) setProjectPath(picked);
+    } catch (err) {
+      console.error('openFolderDialog failed:', err);
+    }
+  }
+
+  async function handleCreate() {
+    if (!projectPath) {
+      setError('Please pick a project first.');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const resolvedModel = template.provider !== 'local' && template.model && template.model !== 'default'
+        ? template.model
+        : undefined;
+      const agent = await createAgent({
+        projectPath,
+        skills: template.skills,
+        character: template.character,
+        name: name.trim() || template.displayName,
+        permissionMode: template.permissionMode,
+        effort: template.effort,
+        provider: template.provider,
+        model: resolvedModel,
+        localModel: template.localModel,
+        obsidianVaultPaths: template.obsidianVaultPaths,
+      });
+      const prompt = template.savedPrompt?.trim() ?? '';
+      if (prompt) {
+        await startAgent(agent.id, prompt, {
+          model: resolvedModel,
+          provider: template.provider,
+          localModel: template.localModel,
+        });
+      }
+      onCreated?.(agent.id);
+      onClose();
+    } catch (err) {
+      console.error('Failed to create agent from template:', err);
+      setError(err instanceof Error ? err.message : 'Failed to create agent');
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div ref={dialogRef} className="bg-card border border-border w-full max-w-lg max-h-[90vh] flex flex-col">
+        <div className="px-5 py-4 border-b border-border flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 min-w-0">
+            <span className="text-2xl shrink-0">{template.icon}</span>
+            <div className="min-w-0">
+              <h2 className="font-semibold text-foreground truncate">Use template: {template.displayName}</h2>
+              <p className="text-xs text-muted-foreground truncate">Pick a project, name your agent, and we&apos;ll set the rest up.</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-1 text-muted-foreground hover:text-foreground" title="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          <div>
+            <label className="block text-xs font-medium text-foreground mb-1.5">Agent name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={40}
+              className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40"
+              placeholder={template.displayName}
+            />
+          </div>
+
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="block text-xs font-medium text-foreground">Project</label>
+              <button
+                onClick={handlePickFolder}
+                className="text-xs text-primary hover:underline flex items-center gap-1"
+              >
+                <FolderOpen className="w-3 h-3" />
+                Pick another folder…
+              </button>
+            </div>
+            <div className="relative mb-2">
+              <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
+              <input
+                type="text"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search your projects…"
+                className="w-full pl-7 pr-2 py-1.5 bg-secondary border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40"
+              />
+            </div>
+            <div className="max-h-56 overflow-y-auto border border-border bg-secondary/30">
+              {filteredProjects.length === 0 ? (
+                <p className="text-xs text-muted-foreground text-center py-4">No projects match. Use &ldquo;Pick another folder…&rdquo; above.</p>
+              ) : (
+                filteredProjects.map(p => (
+                  <button
+                    key={p.path}
+                    onClick={() => setProjectPath(p.path)}
+                    className={`w-full flex flex-col items-start px-3 py-2 text-left text-xs hover:bg-primary/5 transition-colors ${
+                      projectPath === p.path ? 'bg-primary/10 border-l-2 border-l-primary' : ''
+                    }`}
+                  >
+                    <span className="font-medium text-foreground">{p.name}</span>
+                    <span className="text-[10px] text-muted-foreground truncate w-full">{p.path}</span>
+                  </button>
+                ))
+              )}
+            </div>
+            {projectPath && !filteredProjects.some(p => p.path === projectPath) && (
+              <p className="text-[11px] text-muted-foreground mt-1.5">Selected: <span className="text-foreground">{projectPath}</span></p>
+            )}
+          </div>
+
+          {error && (
+            <p className="text-xs text-destructive bg-destructive/10 border border-destructive/30 px-2 py-1.5">{error}</p>
+          )}
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={!projectPath || submitting}
+            className="px-3 py-1.5 text-xs bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+            Create agent
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Templates/TemplateCard.tsx
+++ b/src/components/Templates/TemplateCard.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { Copy, Download, Pencil, Play, Plus, RotateCcw, Trash2 } from 'lucide-react';
+import type { AgentTemplate } from '@/types/electron';
+
+interface TemplateCardProps {
+  template: AgentTemplate;
+  installedSkills: string[];
+  onUse: () => void;
+  onEdit?: () => void;
+  onDuplicate?: () => void;
+  onDelete?: () => void;
+  onReset?: () => void;
+  onExport?: () => void;
+  onInstallSkill?: (skillName: string) => void;
+}
+
+export function TemplateCard({ template, installedSkills, onUse, onEdit, onDuplicate, onDelete, onReset, onExport, onInstallSkill }: TemplateCardProps) {
+  const installedSet = new Set(installedSkills.map(s => s.toLowerCase()));
+  const missingSkills = template.skills.filter(s => !installedSet.has(s.toLowerCase()));
+
+  const providerLabel = template.provider.charAt(0).toUpperCase() + template.provider.slice(1);
+  const modelLabel = template.model ? ` · ${template.model}` : '';
+
+  return (
+    <div className="flex flex-col bg-card border border-border p-4 hover:border-primary/40 transition-colors">
+      <div className="flex items-start gap-3 mb-3">
+        <div className="text-3xl shrink-0 leading-none">{template.icon}</div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <h3 className="font-semibold text-foreground truncate">{template.displayName}</h3>
+            {template.builtin && !template.overridden && (
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground bg-secondary px-1.5 py-0.5">Built-in</span>
+            )}
+            {template.builtin && template.overridden && (
+              <span className="text-[10px] uppercase tracking-wider text-primary bg-primary/10 px-1.5 py-0.5">Customized</span>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {providerLabel}{modelLabel}
+          </p>
+        </div>
+      </div>
+
+      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{template.description}</p>
+
+      {template.skills.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-3">
+          {template.skills.map(skill => {
+            const installed = installedSet.has(skill.toLowerCase());
+            if (installed) {
+              return (
+                <span
+                  key={skill}
+                  className="text-[10px] px-1.5 py-0.5 border bg-secondary border-border text-muted-foreground"
+                  title="Skill installed"
+                >
+                  {skill}
+                </span>
+              );
+            }
+            if (onInstallSkill) {
+              return (
+                <button
+                  key={skill}
+                  onClick={(e) => { e.stopPropagation(); onInstallSkill(skill); }}
+                  className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 border bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-400 hover:bg-amber-500/20 hover:border-amber-500/50 transition-colors cursor-pointer"
+                  title={`Install skill "${skill}"`}
+                >
+                  <Plus className="w-2.5 h-2.5" />
+                  {skill}
+                </button>
+              );
+            }
+            return (
+              <span
+                key={skill}
+                className="text-[10px] px-1.5 py-0.5 border bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-400"
+                title="Skill not installed — visit the Skills page to install"
+              >
+                {skill}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {missingSkills.length > 0 && (
+        <p className="text-[11px] text-amber-700 dark:text-amber-400 mb-3">
+          {missingSkills.length} skill{missingSkills.length > 1 ? 's' : ''} not installed yet
+        </p>
+      )}
+
+      <div className="mt-auto flex items-center gap-2 pt-2">
+        <button
+          onClick={onUse}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 bg-foreground text-background text-xs font-medium hover:bg-foreground/90 transition-colors"
+        >
+          <Play className="w-3 h-3" />
+          Use this template
+        </button>
+        {onDuplicate && (
+          <button
+            onClick={onDuplicate}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            title="Duplicate"
+          >
+            <Copy className="w-3.5 h-3.5" />
+          </button>
+        )}
+        {onExport && (
+          <button
+            onClick={onExport}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            title="Export as JSON"
+          >
+            <Download className="w-3.5 h-3.5" />
+          </button>
+        )}
+        {onEdit && (
+          <button
+            onClick={onEdit}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            title="Edit"
+          >
+            <Pencil className="w-3.5 h-3.5" />
+          </button>
+        )}
+        {onReset && (
+          <button
+            onClick={onReset}
+            className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            title="Reset to default"
+          >
+            <RotateCcw className="w-3.5 h-3.5" />
+          </button>
+        )}
+        {onDelete && (
+          <button
+            onClick={onDelete}
+            className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+            title="Delete"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Templates/TemplateFormDialog.tsx
+++ b/src/components/Templates/TemplateFormDialog.tsx
@@ -56,23 +56,28 @@ export function TemplateFormDialog({ initialTemplate, installedSkills, onClose, 
     }
     setError(null);
     setSubmitting(true);
-    const result = await onSubmit({
-      displayName: displayName.trim(),
-      description: description.trim(),
-      icon: icon.trim() || '🤖',
-      character,
-      provider,
-      model: initialModel,
-      permissionMode,
-      skills,
-      savedPrompt: savedPrompt.trim() || undefined,
-    });
-    if (!result.success) {
-      setError(result.error ?? 'Failed to save template');
+    try {
+      const result = await onSubmit({
+        displayName: displayName.trim(),
+        description: description.trim(),
+        icon: icon.trim() || '🤖',
+        character,
+        provider,
+        model: initialModel,
+        permissionMode,
+        skills,
+        savedPrompt: savedPrompt.trim() || undefined,
+      });
+      if (!result.success) {
+        setError(result.error ?? 'Failed to save template');
+        return;
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save template');
+    } finally {
       setSubmitting(false);
-      return;
     }
-    onClose();
   }
 
   const allSkills = Array.from(new Set([...installedSkills, ...skills])).sort();

--- a/src/components/Templates/TemplateFormDialog.tsx
+++ b/src/components/Templates/TemplateFormDialog.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Loader2, X } from 'lucide-react';
+import type { AgentTemplate, AgentTemplateInput, AgentCharacter, AgentProvider } from '@/types/electron';
+
+const CHARACTERS: AgentCharacter[] = ['robot', 'ninja', 'wizard', 'astronaut', 'knight', 'pirate', 'alien', 'viking'];
+const PROVIDERS: AgentProvider[] = ['claude', 'codex', 'gemini'];
+
+interface TemplateFormDialogProps {
+  initialTemplate?: AgentTemplate | null;
+  installedSkills: string[];
+  onClose: () => void;
+  onSubmit: (input: AgentTemplateInput) => Promise<{ success: boolean; error?: string }>;
+}
+
+export function TemplateFormDialog({ initialTemplate, installedSkills, onClose, onSubmit }: TemplateFormDialogProps) {
+  const [displayName, setDisplayName] = useState(initialTemplate?.displayName ?? '');
+  const [description, setDescription] = useState(initialTemplate?.description ?? '');
+  const [icon, setIcon] = useState(initialTemplate?.icon ?? '🤖');
+  const [character, setCharacter] = useState<AgentCharacter>(initialTemplate?.character ?? 'robot');
+  const [provider, setProvider] = useState<AgentProvider>(initialTemplate?.provider ?? 'claude');
+  // Model is preserved when editing an existing template, but not asked on create —
+  // it falls back to the provider's default.
+  const initialModel = initialTemplate?.model;
+  const [permissionMode, setPermissionMode] = useState<'normal' | 'auto' | 'bypass'>(initialTemplate?.permissionMode ?? 'normal');
+  const [skills, setSkills] = useState<string[]>(initialTemplate?.skills ?? []);
+  const [savedPrompt, setSavedPrompt] = useState(initialTemplate?.savedPrompt ?? '');
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    const onClick = (e: MouseEvent) => {
+      if (dialogRef.current && !dialogRef.current.contains(e.target as Node)) onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    window.addEventListener('mousedown', onClick);
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      window.removeEventListener('mousedown', onClick);
+    };
+  }, [onClose]);
+
+  function toggleSkill(name: string) {
+    setSkills(prev => prev.includes(name) ? prev.filter(s => s !== name) : [...prev, name]);
+  }
+
+  async function handleSubmit() {
+    if (!displayName.trim()) {
+      setError('Name is required');
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    const result = await onSubmit({
+      displayName: displayName.trim(),
+      description: description.trim(),
+      icon: icon.trim() || '🤖',
+      character,
+      provider,
+      model: initialModel,
+      permissionMode,
+      skills,
+      savedPrompt: savedPrompt.trim() || undefined,
+    });
+    if (!result.success) {
+      setError(result.error ?? 'Failed to save template');
+      setSubmitting(false);
+      return;
+    }
+    onClose();
+  }
+
+  const allSkills = Array.from(new Set([...installedSkills, ...skills])).sort();
+
+  return (
+    <div className="fixed inset-0 bg-background/80 backdrop-blur-sm z-50 flex items-center justify-center p-4">
+      <div ref={dialogRef} className="bg-card border border-border w-full max-w-2xl max-h-[90vh] flex flex-col">
+        <div className="px-5 py-4 border-b border-border flex items-center justify-between gap-3">
+          <h2 className="font-semibold text-foreground">
+            {initialTemplate ? 'Edit template' : 'New template'}
+          </h2>
+          <button onClick={onClose} className="p-1 text-muted-foreground hover:text-foreground" title="Close">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+          <div className="grid grid-cols-[80px_1fr] gap-3">
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">Icon</label>
+              <input
+                type="text"
+                value={icon}
+                onChange={e => setIcon(e.target.value)}
+                maxLength={4}
+                className="w-full px-2 py-1.5 bg-secondary border border-border text-2xl text-center text-foreground outline-none focus:border-primary/40"
+              />
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">Name</label>
+              <input
+                type="text"
+                value={displayName}
+                onChange={e => setDisplayName(e.target.value)}
+                maxLength={40}
+                placeholder="e.g. Mobile App Engineer"
+                className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-foreground mb-1.5">Short description</label>
+            <input
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              maxLength={120}
+              placeholder="What does this agent do? (one sentence)"
+              className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">Character</label>
+              <select
+                value={character}
+                onChange={e => setCharacter(e.target.value as AgentCharacter)}
+                className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground outline-none focus:border-primary/40"
+              >
+                {CHARACTERS.map(c => <option key={c} value={c}>{c}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-foreground mb-1.5">Provider</label>
+              <select
+                value={provider}
+                onChange={e => setProvider(e.target.value as AgentProvider)}
+                className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground outline-none focus:border-primary/40"
+              >
+                {PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-foreground mb-1.5">How careful?</label>
+            <div className="flex gap-2">
+              {(['normal', 'auto', 'bypass'] as const).map(m => (
+                <button
+                  key={m}
+                  onClick={() => setPermissionMode(m)}
+                  className={`flex-1 px-2 py-1.5 border text-xs transition-colors ${
+                    permissionMode === m
+                      ? 'bg-primary/15 border-primary text-primary font-medium'
+                      : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {m === 'normal' && 'Ask each time'}
+                  {m === 'auto' && 'Run freely'}
+                  {m === 'bypass' && 'Skip all checks'}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-foreground mb-1.5">
+              Skills <span className="text-muted-foreground font-normal">({skills.length} selected)</span>
+            </label>
+            {allSkills.length === 0 ? (
+              <p className="text-xs text-muted-foreground italic">No skills installed yet — visit the Skills page to install some.</p>
+            ) : (
+              <div className="flex flex-wrap gap-1 max-h-32 overflow-y-auto p-2 border border-border bg-secondary/30">
+                {allSkills.map(skill => {
+                  const selected = skills.includes(skill);
+                  const installed = installedSkills.includes(skill);
+                  return (
+                    <button
+                      key={skill}
+                      onClick={() => toggleSkill(skill)}
+                      className={`text-[10px] px-1.5 py-0.5 border transition-colors ${
+                        selected
+                          ? 'bg-primary/15 border-primary/40 text-primary'
+                          : installed
+                            ? 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+                            : 'bg-amber-500/10 border-amber-500/30 text-amber-700 dark:text-amber-400'
+                      }`}
+                      title={installed ? '' : 'Skill not installed'}
+                    >
+                      {skill}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-foreground mb-1.5">System prompt (optional)</label>
+            <textarea
+              value={savedPrompt}
+              onChange={e => setSavedPrompt(e.target.value)}
+              rows={4}
+              placeholder="Tell the agent how to behave. e.g. 'You are a senior frontend engineer…'"
+              className="w-full px-2 py-1.5 bg-secondary border border-border text-sm text-foreground placeholder:text-muted-foreground outline-none focus:border-primary/40 resize-y"
+            />
+          </div>
+
+          {error && (
+            <p className="text-xs text-destructive bg-destructive/10 border border-destructive/30 px-2 py-1.5">{error}</p>
+          )}
+        </div>
+
+        <div className="px-5 py-3 border-t border-border flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-secondary transition-colors"
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={submitting || !displayName.trim()}
+            className="px-3 py-1.5 text-xs bg-foreground text-background font-medium hover:bg-foreground/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1.5"
+          >
+            {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+            {initialTemplate ? 'Save changes' : 'Create template'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -7,6 +7,23 @@ export interface Release {
 
 export const CHANGELOG: Release[] = [
   {
+    id: 11,
+    version: '1.2.8',
+    date: '2026-05-05',
+    updates: [
+      'Agent Templates — new sidebar page with 9 built-in role templates: Frontend Engineer, Backend Engineer, Security Engineer, Code Reviewer, Tester (QA), Refactor Specialist, Docs Writer, DevOps Engineer, Product Designer',
+      'Production-grade system prompts on every built-in template, grounded in patterns from Cursor, Cline, Roo Code, Anthropic Agent Skills, and the OpenAI Codex prompting guide',
+      'Built-in templates are editable — your edits are saved as overrides with a "Customized" badge and a one-click reset to defaults',
+      '"Use this template" → pick a project → agent created and auto-started with the template prompt; no extra setup',
+      '"Save as template" action on each agent card — turn any working agent into a reusable template',
+      'Clickable "+" badges on missing skills — install marketplace skills directly from a template card; the badge updates live when the install completes',
+      'Import / Export templates as .json files — share role packs with your team or back up your customizations',
+      'Agents list now sorts by creation time by default (newest first), so a freshly created agent appears at the top',
+      'Unlimited dashboard tabs — the previous 5-tab cap is gone; tabs scroll horizontally when they overflow',
+      'New blank template form simplified — no more model picker; uses the provider default',
+    ],
+  },
+  {
     id: 10,
     version: '1.2.7',
     date: '2026-03-28',

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -20,6 +20,7 @@ export const CHANGELOG: Release[] = [
       'Import / Export templates as .json files — share role packs with your team or back up your customizations',
       'Agents list now sorts by creation time by default (newest first), so a freshly created agent appears at the top',
       'Unlimited dashboard tabs — the previous 5-tab cap is gone; tabs scroll horizontally when they overflow',
+      'Ctrl+Tab / Ctrl+Shift+Tab to cycle through dashboard tabs, with focus auto-restored to the last active terminal in each tab — type straight into the agent without clicking',
       'New blank template form simplified — no more model picker; uses the provider default',
     ],
   },

--- a/src/hooks/useAgentFiltering.ts
+++ b/src/hooks/useAgentFiltering.ts
@@ -7,7 +7,7 @@ interface UseAgentFilteringProps {
   projectFilter: string | null;
   statusFilter?: string | null;
   searchQuery?: string;
-  sortBy?: 'status' | 'activity' | 'name';
+  sortBy?: 'created' | 'status' | 'activity' | 'name';
 }
 
 interface UniqueProject {
@@ -15,7 +15,7 @@ interface UniqueProject {
   name: string;
 }
 
-export function useAgentFiltering({ agents, projectFilter, statusFilter, searchQuery, sortBy = 'status' }: UseAgentFilteringProps) {
+export function useAgentFiltering({ agents, projectFilter, statusFilter, searchQuery, sortBy = 'created' }: UseAgentFilteringProps) {
   const uniqueProjects = useMemo(() => {
     const projectSet = new Map<string, string>();
     agents.forEach((agent) => {
@@ -54,10 +54,15 @@ export function useAgentFiltering({ agents, projectFilter, statusFilter, searchQ
       if (sortBy === 'activity') {
         return new Date(b.lastActivity).getTime() - new Date(a.lastActivity).getTime();
       }
-      // Default: status priority
-      const aPriority = getStatusPriority(a.status);
-      const bPriority = getStatusPriority(b.status);
-      return aPriority - bPriority;
+      if (sortBy === 'status') {
+        const aPriority = getStatusPriority(a.status);
+        const bPriority = getStatusPriority(b.status);
+        return aPriority - bPriority;
+      }
+      // Default: created (newest first); fall back to lastActivity for legacy agents missing createdAt
+      const aCreated = new Date(a.createdAt || a.lastActivity).getTime();
+      const bCreated = new Date(b.createdAt || b.lastActivity).getTime();
+      return bCreated - aCreated;
     });
   }, [agents, projectFilter, statusFilter, searchQuery, sortBy]);
 

--- a/src/hooks/useElectronTemplates.ts
+++ b/src/hooks/useElectronTemplates.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { isElectron } from './useElectron';
+import type { AgentTemplate, AgentTemplateInput, AgentTemplatePatch } from '@/types/electron';
+
+export function useElectronTemplates() {
+  const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!isElectron() || !window.electronAPI?.template) {
+      setIsLoading(false);
+      return;
+    }
+    try {
+      const result = await window.electronAPI.template.list();
+      setTemplates(result.templates);
+      setError(result.error ?? null);
+    } catch (err) {
+      console.error('Failed to list templates:', err);
+      setError(err instanceof Error ? err.message : 'Failed to list templates');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  const create = useCallback(async (input: AgentTemplateInput) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    const result = await window.electronAPI.template.create(input);
+    await refresh();
+    return result;
+  }, [refresh]);
+
+  const update = useCallback(async (patch: AgentTemplatePatch) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    const result = await window.electronAPI.template.update(patch);
+    await refresh();
+    return result;
+  }, [refresh]);
+
+  const remove = useCallback(async (id: string) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    const result = await window.electronAPI.template.delete(id);
+    await refresh();
+    return result;
+  }, [refresh]);
+
+  const duplicate = useCallback(async (id: string) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    const result = await window.electronAPI.template.duplicate(id);
+    await refresh();
+    return result;
+  }, [refresh]);
+
+  const exportTemplates = useCallback(async (ids: string[]) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    return window.electronAPI.template.export(ids);
+  }, []);
+
+  const importTemplates = useCallback(async (payload: unknown) => {
+    if (!window.electronAPI?.template) throw new Error('Electron API not available');
+    const result = await window.electronAPI.template.import(payload);
+    await refresh();
+    return result;
+  }, [refresh]);
+
+  return {
+    templates,
+    builtinTemplates: templates.filter(t => t.builtin),
+    userTemplates: templates.filter(t => !t.builtin),
+    isLoading,
+    error,
+    refresh,
+    create,
+    update,
+    remove,
+    duplicate,
+    exportTemplates,
+    importTemplates,
+  };
+}

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -153,6 +153,56 @@ export interface AgentStatus {
   localModel?: string;        // Tasmania model name when provider is 'local'
   savedPrompt?: string;       // Saved task/prompt for re-launching the agent
   obsidianVaultPaths?: string[]; // Obsidian vault paths to mount via --add-dir (read-only)
+  createdAt?: string;         // ISO timestamp when the agent was created
+}
+
+export interface AgentTemplate {
+  id: string;
+  builtin: boolean;
+  /** True if this built-in has been customized by the user. */
+  overridden?: boolean;
+  displayName: string;
+  description: string;
+  icon: string;
+  tags: string[];
+  character: AgentCharacter;
+  provider: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode: 'normal' | 'auto' | 'bypass';
+  effort?: 'low' | 'medium' | 'high';
+  skills: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentTemplateInput {
+  displayName: string;
+  description?: string;
+  icon?: string;
+  tags?: string[];
+  character?: AgentCharacter;
+  provider?: AgentProvider;
+  model?: string;
+  localModel?: string;
+  permissionMode?: 'normal' | 'auto' | 'bypass';
+  effort?: 'low' | 'medium' | 'high';
+  skills?: string[];
+  obsidianVaultPaths?: string[];
+  savedPrompt?: string;
+}
+
+export interface AgentTemplatePatch extends Partial<AgentTemplateInput> {
+  id: string;
+}
+
+export interface TemplateExport {
+  version: number;
+  kind: 'dorothy.agent-template';
+  exportedAt: string;
+  templates: AgentTemplateInput[];
 }
 
 export interface PtyDataEvent {
@@ -789,6 +839,18 @@ export interface ElectronAPI {
     onTaskCreated: (callback: (task: KanbanTaskElectron) => void) => () => void;
     onTaskUpdated: (callback: (task: KanbanTaskElectron) => void) => () => void;
     onTaskDeleted: (callback: (event: { id: string }) => void) => () => void;
+  };
+
+  // Agent templates
+  template?: {
+    list: () => Promise<{ templates: AgentTemplate[]; error?: string }>;
+    get: (id: string) => Promise<{ template: AgentTemplate | null }>;
+    create: (input: AgentTemplateInput) => Promise<{ success: boolean; template?: AgentTemplate; error?: string }>;
+    update: (patch: AgentTemplatePatch) => Promise<{ success: boolean; template?: AgentTemplate; error?: string }>;
+    delete: (id: string) => Promise<{ success: boolean; error?: string }>;
+    duplicate: (id: string) => Promise<{ success: boolean; template?: AgentTemplate; error?: string }>;
+    export: (ids: string[]) => Promise<{ success: boolean; payload?: TemplateExport; error?: string }>;
+    import: (payload: unknown) => Promise<{ success: boolean; imported?: number; skipped?: number; errors?: string[]; templates?: AgentTemplate[]; error?: string }>;
   };
 
   // World (generative zones)


### PR DESCRIPTION
## Summary
Adds a **Templates** page that lets non-technical users spin up a fully-configured agent in one click — pick a role, point at a project, done.

- **9 built-in role templates** with curated skills and production-grade system prompts: Frontend Engineer, Backend Engineer, Security Engineer, Code Reviewer, Tester (QA), Refactor Specialist, Docs Writer, DevOps Engineer, Product Designer.
- Prompts grounded in patterns from [Cursor's leaked system prompts](https://gist.github.com/sshh12/25ad2e40529b269a88b80e7cf1c38084), [Cline's Plan/Act mode](https://github.com/cline/cline/tree/main/src/core/prompts/system-prompt), [Roo Code's mode docs](https://docs.roocode.com/features/custom-modes), [Anthropic's Agent Skills guide](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills), and the OpenAI Codex prompting guide. Each is opinionated, ~150 words, and role-specific (read-only roles forbid edits, destructive roles require confirmation, etc.).
- **Editable built-ins via overrides** — edits land in `~/.dorothy/templates.json` under `overrides[builtinId]`; built-ins keep their slot, gain a "Customized" badge and a one-click reset.
- **Use this template → pick project → auto-start** with the template's system prompt already injected.
- **Save as template** on each agent card to capture a working config as a reusable template.
- **Import / Export** as `.json` (`kind: "dorothy.agent-template"`, `version: 1`) — single or batch, paste-or-upload UI for import.
- **Clickable "+" missing-skill badges** on cards open the same `TerminalDialog` install flow used on the Skills page; refresh on close so the badge flips to installed.

Other QoL fixes that landed alongside:
- Agents list sorts by `createdAt` desc by default — newly instantiated agents appear at the top.
- `createdAt` is set on creation and backfilled from `lastActivity` for legacy agents.
- New blank-template form drops the model picker — uses the provider default.

## Changelog
Bumped to **v1.2.8** in `src/data/changelog.ts`. The What's New entry also includes the **Ctrl+Tab / Ctrl+Shift+Tab dashboard cycling** feature from #51 (already merged) so users on this release see both bundled together.

## Test plan
- [ ] Navigate to **Templates** in the sidebar; confirm 9 built-in role cards render with character emoji, Claude · sonnet, and skill chips.
- [ ] Click **Use this template** on Frontend Engineer → pick a project → confirm a new agent appears at the top of `/agents`, status flips to running, and the saved prompt shows in its terminal.
- [ ] Click ✏️ on a built-in → change the description → save. Confirm the card now shows **Customized** and a ↺ reset button. Click reset → confirm defaults return.
- [ ] Click ⬇ on any card → `.json` downloads. Open it, confirm `kind`, `version`, and one template entry.
- [ ] Click **Import** → paste the exported JSON → confirm preview shows the template name → click Import → confirm it appears under **Your templates**.
- [ ] On a card with amber chips, click a chip → `TerminalDialog` opens → install completes → close → chip flips to grey/installed without manual reload.
- [ ] On `/agents`, click the bookmark+ icon on any agent → name it → confirm it appears under **Your templates**.
- [ ] Visit `/whats-new` → confirm v1.2.8 entry at the top with the bullet list (including the Ctrl+Tab line); sidebar dot clears.