### PR TITLE
chore: bump version to 1.2.8

### DIFF
--- a/landing/src/app/api/download/route.ts
+++ b/landing/src/app/api/download/route.ts
@@ -10,7 +10,7 @@ const redis = process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_RE
   : null;
 
 // Download URL - update this to your actual release URL
-const DOWNLOAD_URL = 'https://github.com/Charlie85270/dorothy/releases/download/1.2.7/dorothy-1.2.7-arm64.dmg';
+const DOWNLOAD_URL = 'https://github.com/Charlie85270/dorothy/releases/download/1.2.8/dorothy-1.2.8-arm64.dmg';
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorothy",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "main": "electron/dist/main.js",
   "scripts": {

--- a/src/components/Settings/GeneralSection.tsx
+++ b/src/components/Settings/GeneralSection.tsx
@@ -164,7 +164,7 @@ export const GeneralSection = ({ info, appSettings, onSaveAppSettings }: General
           <div>
             <h3 className="font-medium">Dorothy</h3>
             <p className="text-sm text-muted-foreground">
-              Version {updateInfo?.currentVersion || '1.2.7'}
+              Version {updateInfo?.currentVersion || '1.2.8'}
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Aligns the published version with the v1.2.8 changelog entry that landed in #54.

- \`package.json\` → \`1.2.8\`
- \`src/components/Settings/GeneralSection.tsx\` → fallback "Version 1.2.8" string when the update-checker hasn't reported yet
- \`landing/src/app/api/download/route.ts\` → \`DOWNLOAD_URL\` points at \`dorothy-1.2.8-arm64.dmg\` on the 1.2.8 GitHub release tag

Merge order suggestion: cut and publish the 1.2.8 GitHub release **first**, then merge this PR — that way the landing-page download link doesn't 404 between merge and release.

## Test plan
- [ ] Confirm \`grep -n 1\\.2\\.7 src landing\` returns nothing related to the app version (only unrelated dep versions in lockfiles).
- [ ] Open the Settings page → General section → see "Version 1.2.8" as the fallback (or whatever the update checker returns once a 1.2.8 release is live).
- [ ] Hit the landing's \`/api/download\` endpoint after the 1.2.8 release is published → confirm 302 redirect to \`dorothy-1.2.8-arm64.dmg\`.