### PR TITLE
fix(api): align POST /start with UI PTY path — MCP for all agents

### DIFF
--- a/electron/services/api-routes/agent-routes.ts
+++ b/electron/services/api-routes/agent-routes.ts
@@ -1,11 +1,10 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import * as pty from 'node-pty';
-import { app } from 'electron';
+import * as os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 import { agents, saveAgents } from '../../core/agent-manager';
 import { ptyProcesses, writeProgrammaticInput } from '../../core/pty-manager';
-import { buildFullPath } from '../../utils/path-builder';
+import { getProvider } from '../../providers';
 import { AgentStatus, AgentCharacter } from '../../types';
 import { RouteApp, RouteContext } from './types';
 
@@ -146,8 +145,8 @@ export function registerAgentRoutes(app_: RouteApp, ctx: RouteContext): void {
     sendJson({ agent });
   });
 
-  // POST /api/agents/:id/start
-  app_.post(/^\/api\/agents\/([^/]+)\/start$/, (req, sendJson) => {
+  // POST /api/agents/:id/start — aligné ipc-handlers (PTY persistant + writeProgrammaticInput)
+  app_.post(/^\/api\/agents\/([^/]+)\/start$/, async (req, sendJson) => {
     const agent = agents.get(req.params.id);
     if (!agent) {
       sendJson({ error: 'Agent not found' }, 404);
@@ -162,107 +161,93 @@ export function registerAgentRoutes(app_: RouteApp, ctx: RouteContext): void {
       return;
     }
 
-    const workingDir = (agent.worktreePath || agent.projectPath).replace(/'/g, "'\\''");
-    let command = `cd '${workingDir}' && claude`;
+    if (model && !/^[a-zA-Z0-9._:/-]+$/.test(model)) {
+      sendJson({ error: 'Invalid model name' }, 400);
+      return;
+    }
+
+    // Recycler le PTY existant pour garantir un /start propre (MCP chargé au boot session).
+    if (agent.ptyId) {
+      const oldPty = ptyProcesses.get(agent.ptyId);
+      if (oldPty) {
+        oldPty.kill();
+        ptyProcesses.delete(agent.ptyId);
+      }
+      agent.ptyId = undefined;
+    }
 
     const isAutomationAgent = agent.name?.toLowerCase().includes('automation:');
     const usePrintMode = printMode || isAutomationAgent;
-
-    if (usePrintMode) {
-      command += ' -p';
-    }
-
     const isSuperAgentApi = agent.name?.toLowerCase().includes('super agent') ||
-                            agent.name?.toLowerCase().includes('orchestrator');
+      agent.name?.toLowerCase().includes('orchestrator');
 
-    if (isSuperAgentApi || isAutomationAgent) {
-      const mcpConfigPath = path.join(app.getPath('home'), '.claude', 'mcp.json');
-      if (fs.existsSync(mcpConfigPath)) {
-        command += ` --mcp-config '${mcpConfigPath}'`;
+    const mcpConfigPath = path.resolve(os.homedir(), '.claude', 'mcp.json');
+    let systemPromptFile: string | undefined;
+    if (isSuperAgentApi) {
+      const { getSuperAgentInstructionsPath } = await import('../../utils');
+      const superAgentInstructionsPath = getSuperAgentInstructionsPath();
+      if (fs.existsSync(superAgentInstructionsPath)) {
+        systemPromptFile = superAgentInstructionsPath;
       }
     }
 
-    if (agent.secondaryProjectPath) {
-      command += ` --add-dir '${agent.secondaryProjectPath.replace(/'/g, "'\\''")}'`;
-    }
+    const appSettings = ctx.getAppSettings();
+    const cliProvider = getProvider(agent.provider || 'claude');
+    const binaryPath = cliProvider.resolveBinaryPath(appSettings);
+
     const effectiveMode = bodyPermissionMode ?? agent.permissionMode ?? (agent.skipPermissions ? 'auto' : 'normal');
-    if (effectiveMode === 'auto' || effectiveMode === 'bypass') {
-      command += ' --dangerously-skip-permissions';
-    }
-    const resolvedModel = model || agent.model;
-    if (resolvedModel) {
-      if (!/^[a-zA-Z0-9._:/-]+$/.test(resolvedModel)) {
-        sendJson({ error: 'Invalid model name' }, 400);
-        return;
-      }
-      command += ` --model '${resolvedModel}'`;
-    }
+    const permissionMode = isSuperAgentApi ? 'bypass' : effectiveMode;
 
-    let finalPrompt = prompt;
-    if (agent.skills && agent.skills.length > 0 && !isSuperAgentApi) {
-      const skillsList = agent.skills.join(', ');
-      finalPrompt = `[IMPORTANT: Use these skills for this session: ${skillsList}. Invoke them with /<skill-name> when relevant to the task.] ${prompt}`;
-    }
-    command += ` '${finalPrompt.replace(/'/g, "'\\''")}'`;
-
-    const shell = '/bin/bash';
-    const fullPath = buildFullPath();
-
-    const ptyProcess = pty.spawn(shell, ['-l', '-c', command], {
-      name: 'xterm-256color',
-      cols: 120,
-      rows: 40,
-      cwd: workingDir,
-      env: {
-        ...process.env,
-        PATH: fullPath,
-        TERM: 'xterm-256color',
-        CLAUDE_SKILLS: agent.skills?.join(',') || '',
-        CLAUDE_AGENT_ID: agent.id,
-        CLAUDE_PROJECT_PATH: agent.projectPath,
-      },
+    let command = cliProvider.buildInteractiveCommand({
+      binaryPath,
+      prompt,
+      model: model || agent.model,
+      verbose: appSettings.verboseModeEnabled,
+      permissionMode,
+      effort: agent.effort,
+      secondaryProjectPath: agent.secondaryProjectPath,
+      obsidianVaultPaths: agent.obsidianVaultPaths,
+      mcpConfigPath: fs.existsSync(mcpConfigPath) ? mcpConfigPath : undefined,
+      systemPromptFile,
+      skills: [...new Set([...(agent.skills || []), 'world-builder'])],
+      isSuperAgent: isSuperAgentApi,
+      chrome: appSettings.chromeEnabled,
     });
 
-    const ptyId = uuidv4();
-    ptyProcesses.set(ptyId, ptyProcess);
+    if (usePrintMode) {
+      command = command.replace(/^'([^']*(?:\\'[^']*)*)'/, (m) => `${m} -p`);
+    }
+
+    const workingPath = (agent.worktreePath || agent.projectPath).replace(/'/g, "'\\''");
+    const fullCommand = `cd '${workingPath}' && ${command}`;
+
+    let ptyId: string;
+    try {
+      ptyId = await ctx.initAgentPtyCallback(agent);
+    } catch (e) {
+      sendJson({ error: `PTY init failed: ${String((e as Error)?.message || e)}` }, 500);
+      return;
+    }
 
     agent.ptyId = ptyId;
+    const ptyProcess = ptyProcesses.get(ptyId);
+    if (!ptyProcess) {
+      sendJson({ error: 'PTY not found after init' }, 500);
+      return;
+    }
+
     agent.status = 'running';
     agent.currentTask = prompt;
     agent.output = [];
-    agent.lastCleanOutput = undefined;  // Clear stale output from previous task
-    agent.error = undefined;            // Clear previous error state
+    agent.lastCleanOutput = undefined;
+    agent.error = undefined;
     agent.lastActivity = new Date().toISOString();
     saveAgents();
+    ctx.agentStatusEmitter.emit(`status:${agent.id}`);
 
-    ptyProcess.onData((data: string) => {
-      agent.output.push(data);
-      if (agent.output.length > 10000) {
-        agent.output = agent.output.slice(-5000);
-      }
-      agent.lastActivity = new Date().toISOString();
-
-      if (ctx.mainWindow && !ctx.mainWindow.isDestroyed()) {
-        ctx.mainWindow.webContents.send('agent:output', { agentId: agent.id, data });
-      }
-    });
-
-    ptyProcess.onExit(({ exitCode }) => {
-      // Delay status change to let hooks (on-stop.sh, task-completed.sh) finish
-      // capturing output before wait_for_agent resolves.
-      setTimeout(() => {
-        if (agent.status === 'running') {
-          agent.status = exitCode === 0 ? 'completed' : 'error';
-        }
-        if (exitCode !== 0) {
-          agent.error = `Process exited with code ${exitCode}`;
-        }
-        agent.lastActivity = new Date().toISOString();
-        ptyProcesses.delete(ptyId);
-        saveAgents();
-        ctx.agentStatusEmitter.emit(`status:${agent.id}`);
-      }, 1500);
-    });
+    setTimeout(() => {
+      writeProgrammaticInput(ptyProcess, fullCommand);
+    }, 500);
 
     sendJson({ success: true, agent: { id: agent.id, status: agent.status } });
   });


### PR DESCRIPTION
## Summary

The HTTP API `POST /api/agents/:id/start` previously spawned a one-shot `bash -l -c "cd … && claude …"` session and only passed `--mcp-config` for Super Agent / Automation agents. Mission workers (Docs, Backend, Security, Frontend, QA) started via the API therefore had **no MCP** loaded — breaking ZAIOS Relay integration (`relay_runtime_tools` invisible).

This PR aligns the HTTP `/start` route with the existing UI path (`ipc-handlers` `agent:start`):

- Kill/recycle stale PTY before start
- `initAgentPtyCallback` + persistent PTY
- `getProvider('claude').buildInteractiveCommand({ mcpConfigPath, … })`
- `writeProgrammaticInput(pty, \`cd '…' && ${command}\`)` after 500ms settle
- `--mcp-config ~/.claude/mcp.json` for **all** agents when the file exists

## Context

Validated in ZAIOS Mission #2 (`avec_svc`) with `dorothy-mcp-attach` smoke 6/6 and Dorothy live mobilize 6/6. ZAIOS canon: PRs #81–#83 on `Zai69/zaios`.

## Test plan

- [ ] Restart Dorothy after merge (`tsc -p electron/tsconfig.json` runs on `electron:start`)
- [ ] Start a non–Super-Agent worker via API with a prompt referencing MCP
- [ ] Confirm `~/.claude/mcp.json` servers appear in Claude session (no `MCP config file not found`)
- [ ] ZAIOS: `make dorothy-mcp-attach` → 6/6 OK

## Scope

Single file: `electron/services/api-routes/agent-routes.ts` — no UI or ipc-handlers changes.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent startup reliability by ensuring proper cleanup of existing sessions before initialization.
  * Added validation for required agent configuration parameters.
  * Enhanced state management with better tracking of agent status and activity.

* **Refactor**
  * Restructured agent initialization process for improved reliability and system integration.
  * Improved event handling during agent startup and lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Charlie85270/Dorothy/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->