### PR TITLE
fix: submit short Telegram/Slack messages instead of leaving them pasted

### DIFF
--- a/__tests__/electron/core/pty-manager.test.ts
+++ b/__tests__/electron/core/pty-manager.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// pty-manager imports node-pty (native) and electron at module load — mock both
+// so the module can be imported in the test environment.
+vi.mock('node-pty', () => ({ spawn: vi.fn() }));
+vi.mock('electron', () => ({ BrowserWindow: vi.fn() }));
+
+import { writeProgrammaticInput } from '../../../electron/core/pty-manager';
+import type { IPty } from 'node-pty';
+
+function makeFakePty() {
+  const writes: string[] = [];
+  const pty = {
+    write: vi.fn((data: string) => {
+      writes.push(data);
+    }),
+  } as unknown as IPty;
+  return { pty, writes };
+}
+
+describe('writeProgrammaticInput', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('sends a raw shell command as text + \\r in a single write (bracketPaste = false)', () => {
+    const { pty, writes } = makeFakePty();
+    writeProgrammaticInput(pty, "cd '/tmp' && claude");
+    expect(writes).toEqual(["cd '/tmp' && claude\r"]);
+  });
+
+  it('delays the carriage return for a short single-line message (bracketPaste = true)', () => {
+    // Regression: short Telegram/Slack messages must NOT be sent as an atomic
+    // "text\r" — Claude Code's TUI treats that as a paste event and never
+    // submits. The \r has to be a separate, delayed write.
+    const { pty, writes } = makeFakePty();
+    const msg = '[FROM TELEGRAM chat_id=123] hey, check the deploy';
+    expect(msg.length).toBeLessThan(200);
+    expect(msg).not.toContain('\n');
+
+    writeProgrammaticInput(pty, msg, true);
+
+    // Text is written immediately, but the \r has NOT been sent yet.
+    expect(writes).toEqual([msg]);
+
+    vi.advanceTimersByTime(300);
+    expect(writes).toEqual([msg, '\r']);
+  });
+
+  it('wraps long/multi-line input in bracket paste markers with a delayed \\r', () => {
+    const { pty, writes } = makeFakePty();
+    const msg = 'line one\nline two';
+
+    writeProgrammaticInput(pty, msg, true);
+    expect(writes).toEqual(['\x1b[200~' + msg + '\x1b[201~']);
+
+    vi.advanceTimersByTime(300);
+    expect(writes).toEqual(['\x1b[200~' + msg + '\x1b[201~', '\r']);
+  });
+});

--- a/electron/core/pty-manager.ts
+++ b/electron/core/pty-manager.ts
@@ -41,13 +41,18 @@ export function killAllPty(): void {
  * Write a command to a PTY and submit it.
  *
  * When `bracketPaste` is true (used for sending messages to an already-running
- * Claude Code session), multi-line / long input is wrapped in bracket paste
- * mode so the terminal treats it as a single paste.  A short delay before the
- * final carriage-return ensures the paste buffer is fully processed.
+ * Claude Code session), the carriage return is ALWAYS sent as a separate,
+ * delayed write — even for short single-line messages. Claude Code's TUI treats
+ * a rapid "text\r" burst as a single paste event and buffers it without
+ * submitting (the text lands in the input box as "[Pasted text]" but is never
+ * sent). Delaying the \r lets the paste settle so it registers as a deliberate
+ * submit keystroke. Multi-line / long input is additionally wrapped in bracket
+ * paste markers so the terminal treats it as one paste rather than line-by-line
+ * input.
  *
  * When `bracketPaste` is false (default — used for the initial shell command
  * that starts Claude Code), the data is sent as plain text + \r, which is what
- * a raw bash/zsh shell expects.
+ * a raw bash/zsh shell expects and has no paste-detection race.
  *
  * DO NOT use this for raw keystroke passthrough from xterm.js UI terminals.
  */
@@ -56,14 +61,22 @@ export function writeProgrammaticInput(
   data: string,
   bracketPaste = false,
 ): void {
-  if (bracketPaste && (data.includes('\n') || data.length > 200)) {
-    // Bracket paste mode: \x1b[200~ ... \x1b[201~ tells the terminal
-    // "everything between these markers is pasted content, not typed input"
-    ptyProcess.write('\x1b[200~' + data + '\x1b[201~');
-    // Delay the carriage return so the terminal finishes processing the paste
+  if (bracketPaste) {
+    if (data.includes('\n') || data.length > 200) {
+      // Bracket paste mode: \x1b[200~ ... \x1b[201~ tells the terminal
+      // "everything between these markers is pasted content, not typed input"
+      ptyProcess.write('\x1b[200~' + data + '\x1b[201~');
+    } else {
+      // Short single-line message: no bracket markers needed, but the \r must
+      // still be delayed (see below) so it isn't swallowed into the paste.
+      ptyProcess.write(data);
+    }
+    // Delay the carriage return so the TUI finishes processing the input before
+    // receiving the submit keystroke. Without this, short Telegram/Slack
+    // messages get typed into the box but never sent.
     setTimeout(() => ptyProcess.write('\r'), 300);
   } else {
-    // Short single-line input or shell command: send directly
+    // Plain shell command for a raw bash/zsh prompt: send directly.
     ptyProcess.write(data + '\r');
   }
 }


### PR DESCRIPTION
## Problem

When someone sends a message via Telegram, the message often gets **written into the Super Agent's terminal but never submitted** — it sits in Claude Code's input box (as `[Pasted text]`) and the super agent never processes it. Same intermittent failure affects Slack messages.

## Root cause

A regression introduced in #43.

- **#39** fixed the original bug (#38) by always sending the carriage return as a **separate, delayed** write. Claude Code's TUI treats a rapid `text\r` burst as a single *paste* event and buffers it without submitting; delaying the `\r` lets the paste settle so it registers as a real submit keystroke.
- **#43** refactored `writeProgrammaticInput` and only kept the delayed `\r` for **multi-line / >200-char** input. Short input fell back to an atomic `ptyProcess.write(data + '\r')`.

Telegram/Slack messages strip newlines to spaces (`telegram-bot.ts`) and are usually well under 200 chars, so **nearly every message hit the atomic path** and intermittently failed to submit.

```ts
// before — short single-line messages went here:
} else {
  ptyProcess.write(data + '\r'); // atomic burst → treated as unsubmitted paste
}
```

## Fix

When `bracketPaste` is `true` (i.e. sending to an already-running Claude Code session), **always** send the `\r` as a separate delayed write, regardless of length. Bracket-paste markers (`\x1b[200~`…`\x1b[201~`) are still only added for multi-line / long input. Raw shell commands (`bracketPaste = false`) are unchanged.

## Tests

Adds `__tests__/electron/core/pty-manager.test.ts` covering:
- raw shell command → single atomic `text\r` write
- short single-line message → text written immediately, `\r` delayed
- long/multi-line message → bracket-paste markers + delayed `\r`

Full electron suite: **468 passed**. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how programmatic terminal input is sent, making Enter key behavior more reliable across short commands and longer multi-line input.
  * Better handling of bracket-paste mode so input is delivered in the expected format and the final carriage return is sent separately.

* **Tests**
  * Added coverage for terminal input behavior in both standard and bracket-paste modes, including delayed Enter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->