### PR TITLE
feat: add Linux dev setup and launch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,42 @@ Output in `release/`:
 - **macOS**: `release/mac-arm64/Dorothy.app` (Apple Silicon) or `release/mac/Dorothy.app` (Intel)
 - DMG installer included
 
+### Linux (Development)
+
+`scripts/run-linux.sh` takes a fresh checkout to a running app in one command:
+
+```bash
+npm run dev:linux                    # Electron dev mode
+npm run dev:linux -- --web           # Browser-only mode (http://localhost:3000)
+npm run dev:linux -- --skip-install  # Skip the dependency install step
+npm run dev:linux -- --help
+```
+
+The script checks prerequisites, installs dependencies when they are missing or
+stale, rebuilds the native modules against the Electron ABI, and starts
+`npm run electron:dev`. Ctrl-C stops the whole dev stack — no orphaned
+`next`/`electron` processes.
+
+**Requirements** (the script reports the exact `apt` line when something is missing):
+
+- **Node.js 22+** — the version in `.nvmrc`. Not in the Ubuntu/Debian archives, install it via [nvm](https://github.com/nvm-sh/nvm) or [NodeSource](https://github.com/nodesource/distributions).
+- **Build toolchain** — `sudo apt install -y build-essential python3`. `better-sqlite3` and `node-pty` have no prebuilt binaries for the Electron ABI, so they compile from source.
+
+**Notes:**
+
+- The Electron rebuild is slow, so it is cached with a stamp file
+  (`node_modules/.dorothy-electron-rebuild`) and only re-runs when the Electron
+  version or the Node ABI changes.
+- On Ubuntu 24.04+ (`kernel.apparmor_restrict_unprivileged_userns=1`) the kernel
+  blocks unprivileged user namespaces and Electron's sandbox fails to start. The
+  script detects this and exports `ELECTRON_DISABLE_SANDBOX=1`, printing a line
+  explaining what it did. On kernels without the restriction nothing changes.
+- Port 3000 must be free — `next dev` silently falls back to another port and the
+  Electron window would then wait forever for `http://localhost:3000`.
+
+Packaging is macOS-only for now (`electron:build` / `electron:pack` pass `--mac`);
+this script covers development mode.
+
 ### Web Browser (Development)
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
+    "dev:linux": "bash scripts/run-linux.sh",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+#
+# Set up and launch Dorothy in development mode on Linux.
+#
+#   scripts/run-linux.sh                 Electron dev mode (default)
+#   scripts/run-linux.sh --web           Browser-only mode on http://localhost:3000
+#   scripts/run-linux.sh --skip-install   Skip dependency install
+#   scripts/run-linux.sh --help
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DEV_PORT=3000
+REBUILD_STAMP="node_modules/.dorothy-electron-rebuild"
+
+SKIP_INSTALL=0
+WEB_MODE=0
+
+if [ -t 1 ]; then
+  C_BOLD=$'\033[1m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_BLUE=$'\033[34m'; C_OFF=$'\033[0m'
+else
+  C_BOLD=''; C_RED=''; C_YELLOW=''; C_BLUE=''; C_OFF=''
+fi
+
+log()  { printf '%s\n' "${C_BLUE}==>${C_OFF} $*"; }
+warn() { printf '%s\n' "${C_YELLOW}warning:${C_OFF} $*" >&2; }
+err()  { printf '%s\n' "${C_RED}error:${C_OFF} $*" >&2; }
+die()  { err "$@"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-linux.sh [options]
+
+Sets up a Linux checkout of Dorothy and launches it in development mode:
+checks prerequisites, installs dependencies, rebuilds the native modules
+(better-sqlite3, node-pty) against the Electron ABI, then starts the app.
+
+Options:
+  --web            Run browser-only mode (next dev on http://localhost:3000).
+                   Skips Electron and the native-module rebuild.
+  --skip-install   Do not run "npm install" even if dependencies look stale.
+  -h, --help       Show this help.
+
+Notes:
+  * The Electron rebuild is cached with a stamp file
+    (node_modules/.dorothy-electron-rebuild) and only re-runs when the Electron
+    version or the Node ABI changes.
+  * --web leaves the native modules built for the Electron ABI. Nothing under
+    src/ loads them, but a plain "node" script that does would need
+    "npm rebuild better-sqlite3 node-pty" first.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --web) WEB_MODE=1 ;;
+    --skip-install) SKIP_INSTALL=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) err "unknown option: $1"; echo >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------- prerequisites
+
+required_node_major() {
+  local version=22
+  if [ -f .nvmrc ]; then
+    local pinned
+    pinned="$(tr -d '[:space:]v' < .nvmrc)"
+    pinned="${pinned%%.*}"
+    case "$pinned" in ''|*[!0-9]*) ;; *) version="$pinned" ;; esac
+  fi
+  printf '%s' "$version"
+}
+
+check_prerequisites() {
+  local node_major want_major
+  local -a problems=() apt_packages=()
+
+  want_major="$(required_node_major)"
+
+  if command -v node >/dev/null 2>&1; then
+    node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+    if [ "$node_major" -lt "$want_major" ]; then
+      problems+=("Node.js $(node -v) is too old — Dorothy needs Node >= ${want_major} (see .nvmrc).")
+    fi
+  else
+    problems+=("Node.js is not installed — Dorothy needs Node >= ${want_major} (see .nvmrc).")
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    problems+=("npm is not installed (it ships with Node.js).")
+  fi
+
+  # better-sqlite3 and node-pty have no prebuilt binaries for the Electron ABI,
+  # so node-gyp compiles them from source here.
+  if ! command -v python3 >/dev/null 2>&1; then
+    problems+=("python3 is not installed — node-gyp needs it to build better-sqlite3 and node-pty.")
+    apt_packages+=("python3")
+  fi
+
+  local -a missing_toolchain=()
+  command -v make >/dev/null 2>&1 || missing_toolchain+=("make")
+  command -v g++ >/dev/null 2>&1 || missing_toolchain+=("g++")
+  if [ ${#missing_toolchain[@]} -gt 0 ]; then
+    problems+=("No C++ toolchain (missing: ${missing_toolchain[*]}) — better-sqlite3 and node-pty compile from source.")
+    apt_packages+=("build-essential")
+  fi
+
+  if [ ${#problems[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  err "missing prerequisites:"
+  local problem
+  for problem in "${problems[@]}"; do
+    printf '  - %s\n' "$problem" >&2
+  done
+  printf '\n' >&2
+  if [ ${#apt_packages[@]} -gt 0 ]; then
+    printf '%s\n' "  On Debian/Ubuntu: ${C_BOLD}sudo apt install -y ${apt_packages[*]}${C_OFF}" >&2
+  fi
+  if ! command -v node >/dev/null 2>&1 || [ "${node_major:-0}" -lt "$want_major" ]; then
+    printf '%s\n' "  Node ${want_major} is not in the Ubuntu/Debian archives — install it with nvm:" >&2
+    printf '%s\n' "    ${C_BOLD}curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && nvm install ${want_major}${C_OFF}" >&2
+    printf '%s\n' "  or from NodeSource: ${C_BOLD}https://github.com/nodesource/distributions${C_OFF}" >&2
+  fi
+  exit 1
+}
+
+# next dev silently falls back to another port when 3000 is taken, and then
+# "wait-on http://localhost:3000" in electron:dev waits forever.
+check_port_free() {
+  local busy=0
+  if command -v ss >/dev/null 2>&1; then
+    if ss -ltnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${DEV_PORT}$"; then
+      busy=1
+    fi
+  elif command -v lsof >/dev/null 2>&1; then
+    if lsof -iTCP:"${DEV_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+      busy=1
+    fi
+  else
+    return 0
+  fi
+
+  if [ "$busy" -eq 1 ]; then
+    err "port ${DEV_PORT} is already in use."
+    printf '%s\n' "  Dorothy's dev server must own port ${DEV_PORT}: next dev would fall back to another" >&2
+    printf '%s\n' "  port and the app would never connect. Stop the other server, e.g.:" >&2
+    printf '%s\n' "    ${C_BOLD}fuser -k ${DEV_PORT}/tcp${C_OFF}" >&2
+    exit 1
+  fi
+}
+
+# ------------------------------------------------------------------- install
+
+dependencies_stale() {
+  if [ ! -d node_modules ]; then
+    return 0
+  fi
+  if [ ! -f node_modules/.package-lock.json ]; then
+    return 0
+  fi
+  if [ package-lock.json -nt node_modules/.package-lock.json ] || [ package.json -nt node_modules/.package-lock.json ]; then
+    return 0
+  fi
+  return 1
+}
+
+install_dependencies() {
+  if [ "$SKIP_INSTALL" -eq 1 ]; then
+    if [ ! -d node_modules ]; then
+      die "--skip-install was passed but node_modules/ does not exist. Run without --skip-install first."
+    fi
+    log "Skipping dependency install (--skip-install)."
+    return 0
+  fi
+
+  if dependencies_stale; then
+    log "Installing dependencies (npm install) — this takes a few minutes on a fresh checkout..."
+    npm install
+  else
+    log "Dependencies are up to date."
+  fi
+}
+
+# ------------------------------------------------------- native module rebuild
+
+rebuild_native_modules() {
+  local electron_version node_abi want current
+
+  if [ ! -d node_modules/electron ]; then
+    die "node_modules/electron is missing — run without --skip-install so dependencies get installed."
+  fi
+
+  electron_version="$(node -p "require('electron/package.json').version")"
+  node_abi="$(node -p 'process.versions.modules')"
+  want="electron=${electron_version} node-abi=${node_abi}"
+
+  current=""
+  if [ -f "$REBUILD_STAMP" ]; then
+    current="$(cat "$REBUILD_STAMP")"
+  fi
+
+  if [ "$current" = "$want" ]; then
+    log "Native modules already built for Electron ${electron_version} (stamp: ${REBUILD_STAMP})."
+    return 0
+  fi
+
+  log "Rebuilding better-sqlite3 and node-pty for Electron ${electron_version} — this is slow, but it is cached..."
+  npx @electron/rebuild --force --only better-sqlite3,node-pty
+  printf '%s\n' "$want" > "$REBUILD_STAMP"
+}
+
+# ------------------------------------------------------------ electron sandbox
+
+read_userns_restriction() {
+  local value="" sysctl_bin
+  for sysctl_bin in sysctl /usr/sbin/sysctl /sbin/sysctl; do
+    if command -v "$sysctl_bin" >/dev/null 2>&1; then
+      value="$("$sysctl_bin" -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+      break
+    fi
+  done
+  if [ -z "$value" ] && [ -r /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+    value="$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+  fi
+  printf '%s' "${value:-0}"
+}
+
+configure_electron_sandbox() {
+  if [ "$(read_userns_restriction)" != "1" ]; then
+    return 0
+  fi
+  export ELECTRON_DISABLE_SANDBOX=1
+  log "kernel.apparmor_restrict_unprivileged_userns=1, so exported ELECTRON_DISABLE_SANDBOX=1: this kernel (Ubuntu 24.04+) blocks unprivileged user namespaces and Electron's sandbox would fail to start without it."
+}
+
+# ------------------------------------------------------------------- launching
+
+CHILD_PID=""
+CLEANED_UP=0
+
+cleanup() {
+  if [ "$CLEANED_UP" -eq 1 ]; then
+    return 0
+  fi
+  CLEANED_UP=1
+  trap - INT TERM EXIT
+
+  if [ -n "$CHILD_PID" ] && kill -0 "$CHILD_PID" 2>/dev/null; then
+    log "Shutting down dev processes..."
+    kill -TERM -"$CHILD_PID" 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null || true
+    local waited=0
+    while [ "$waited" -lt 50 ] && kill -0 "$CHILD_PID" 2>/dev/null; do
+      sleep 0.1
+      waited=$((waited + 1))
+    done
+    kill -KILL -"$CHILD_PID" 2>/dev/null || true
+  fi
+}
+
+launch() {
+  local -a command
+  if [ "$WEB_MODE" -eq 1 ]; then
+    command=(npm run dev)
+    log "Starting browser-only mode — open http://localhost:${DEV_PORT} (Ctrl-C to stop)."
+  else
+    command=(npm run electron:dev)
+    log "Starting Electron dev mode — the window opens once http://localhost:${DEV_PORT} is up (Ctrl-C to stop)."
+  fi
+
+  # Job control puts the child in its own process group so that Ctrl-C tears
+  # down every next/electron process instead of orphaning them.
+  set -m
+  "${command[@]}" < /dev/null &
+  CHILD_PID=$!
+  set +m
+
+  trap cleanup INT TERM EXIT
+
+  local status=0
+  wait "$CHILD_PID" || status=$?
+  cleanup
+
+  # 130/143 mean the user stopped it with Ctrl-C, which is a normal exit.
+  if [ "$status" -eq 130 ] || [ "$status" -eq 143 ]; then
+    status=0
+  fi
+  return "$status"
+}
+
+# ----------------------------------------------------------------------- main
+
+log "Dorothy dev launcher (${REPO_ROOT})"
+check_prerequisites
+check_port_free
+install_dependencies
+if [ "$WEB_MODE" -eq 0 ]; then
+  rebuild_native_modules
+  configure_electron_sandbox
+fi
+launch

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -183,6 +183,9 @@ install_dependencies() {
   if dependencies_stale; then
     log "Installing dependencies (npm install) — this takes a few minutes on a fresh checkout..."
     npm install
+    # An install can restore the Node-ABI build of a native module, so the
+    # cached Electron rebuild can no longer be trusted.
+    rm -f "$REBUILD_STAMP"
   else
     log "Dependencies are up to date."
   fi


### PR DESCRIPTION
## Summary

Adds `scripts/run-linux.sh`, a one-command path from a fresh Linux checkout to a running Dorothy dev app, plus an `npm run dev:linux` alias and a Linux section in the README under *Installation → Build from Source*.

The script:

1. **Checks prerequisites** and fails with actionable messages — Node >= 22 (read from `.nvmrc`), npm, python3, and a C++ toolchain (`make`/`g++`), since `better-sqlite3` and `node-pty` compile from source. It prints one combined `sudo apt install -y ...` line, and points at nvm/NodeSource for Node (22 is not in the Ubuntu/Debian archives).
2. **Installs dependencies** when `node_modules/` is absent or older than `package.json`/`package-lock.json`; `--skip-install` opts out.
3. **Rebuilds the native modules** for the Electron ABI via `npx @electron/rebuild --force --only better-sqlite3,node-pty`, cached behind a stamp file (`node_modules/.dorothy-electron-rebuild`, keyed on Electron version + Node ABI) so the slow step does not re-run on every launch. The stamp is dropped after an install, because an install can restore the Node-ABI prebuilt while the stamp still matches.
4. **Handles the Ubuntu 24.04 sandbox restriction** — when `kernel.apparmor_restrict_unprivileged_userns=1` it exports `ELECTRON_DISABLE_SANDBOX=1` and prints a one-line explanation. When the restriction is absent it changes nothing.
5. **Launches `npm run electron:dev`** in its own process group, so Ctrl-C tears down the whole next/electron tree instead of orphaning it.
6. **Supports `--web`** (browser-only `next dev` on port 3000, skipping the Electron rebuild and sandbox handling) and `--help`.

It also guards port 3000 up front: `next dev` silently falls back to another port when it is taken, and `wait-on http://localhost:3000` would then hang forever.

## Tests run

All on Linux Mint 22 (Ubuntu 24.04 base), kernel 6.8, Node 22.17.1, Electron 33.4.11, X11.

| Check | Result |
|---|---|
| `bash -n scripts/run-linux.sh` | OK |
| `shellcheck --shell=bash` (0.11.0) | clean, 0 findings |
| Full run from a checkout with **no** `node_modules` | install (48s) → rebuild → Electron window up; `GET /` 200, `/api/agents` 200 |
| Native modules under Electron | `new Database(':memory:')` insert/select OK, `pty.spawn` OK at ABI 130 |
| Rebuild actually retargets the ABI | `better_sqlite3.node` exports `node_register_module_v130`; `node-pty/bin/linux-x64-130/` created by the rebuild |
| Second run with `--skip-install` | stamp short-circuits the rebuild, app up in < 25s |
| Stamp invalidation after install | `touch package.json` → install → rebuild re-runs (this was a bug found in review and fixed) |
| Ctrl-C shutdown | SIGINT to the process group via `npm run dev:linux`: 0 group members, 0 Electron processes (checked via `/proc/PID/exe`), 0 `next-server`, port 3000 free |
| `--web` | `next dev` only, no Electron, `GET /` 200, clean shutdown |
| `npm run dev:linux -- --help` / `-- --skip-install` | arg passthrough works |
| Port 3000 already in use | refuses with a clear message, exit 1 |
| Missing python3 + toolchain | reports both, prints `sudo apt install -y python3 build-essential`, exit 1 |
| Node absent / Node 18 | reports the version gap and the nvm install line, exit 1 |
| `--skip-install` with no `node_modules` | refuses with a clear message, exit 1 |
| Unknown flag / `--help` | exit 1 with usage / exit 0 |

Notes on the verification:

- This host reports `kernel.apparmor_restrict_unprivileged_userns=0`, so the sandbox branch cannot fire natively here. It was exercised with a PATH stub returning `1`: the explanation line printed, `ELECTRON_DISABLE_SANDBOX=1` propagated to every child process, and the renderers came up with `--no-sandbox`. The same run without the stub produced no sandbox line, no env var, and no `--no-sandbox` — so the branch is a genuine no-op when the restriction is absent.
- `tsc -p electron/tsconfig.json` passes — `electron:start` gates on it and the window came up.
- Launching the app runs Dorothy's own first-launch setup, which installs skills and hooks into `~/.claude`, `~/.gemini`, `~/.agents`, `~/.grok`, `~/.pi` and rewrites `~/.claude/settings.json`. That is existing app behaviour, not something the script does, but it does happen the first time anyone runs this.

## Risks

- The rebuild cache is keyed on Electron version + Node ABI. Editing a native dependency's source without changing its version would not invalidate it; delete `node_modules/.dorothy-electron-rebuild` to force a rebuild.
- After an Electron rebuild, `better-sqlite3` no longer loads under plain `node` (ABI 130 vs 127). Nothing under `src/` imports it — `--web` mode serves `/` and `/api/agents` fine — but a standalone node script that needs it would want `npm rebuild better-sqlite3 node-pty` first. This is documented in `--help` and the README.
- The script assumes port 3000; it does not offer a port override, matching the hardcoded port in `electron:dev`.

## Follow-ups (out of scope here)

- Automations register launchd jobs on darwin only, with no cron fallback (`electron/handlers/automation-handlers.ts:463,499,529`), so they never fire on Linux. The Scheduler is fine — it wires `createCronJob` at `electron/handlers/scheduler-handlers.ts:878,1102`.
- `shell:open-terminal` uses osascript/Terminal.app (`electron/handlers/ipc-handlers.ts:2003`).
- "Open in Cursor" uses `open -a` (`src/components/AgentWorld/GitPanel.tsx:228`).
- No linux target in the electron-builder config, and `electron:build`/`electron:pack` hardcode `--mac`. Packaging is a separate task; this script covers dev mode only.

Unrelated observation: running `npm install` rewrites the `version` field in `package-lock.json` from 1.2.6 to 1.2.9 to match `package.json`. That drift is pre-existing and was reverted here to keep this PR scoped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Linux development launcher with Electron and browser modes.
  * Added prerequisite checks, dependency setup, native-module rebuilding, port validation, and process cleanup.
  * Added support for restricted Linux environments through Electron sandbox handling.
  * Added the `npm run dev:linux` command.

* **Documentation**
  * Added Linux development setup and usage instructions.
  * Documented supported launch modes, requirements, troubleshooting considerations, and platform-specific packaging scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->